### PR TITLE
Updates hs-abci for modern tendermint version (01-2018)

### DIFF
--- a/hs-abci.cabal
+++ b/hs-abci.cabal
@@ -1,5 +1,5 @@
 name:                hs-abci
-version:             0.1.0.0
+version:             0.1.1.0
 synopsis:            Tendermint's ABCI server library
 description:         TBD
 homepage:            https://github.com/albertov/hs-abci#readme

--- a/src/Network/ABCI/types.proto
+++ b/src/Network/ABCI/types.proto
@@ -1,241 +1,258 @@
 syntax = "proto3";
 package types;
 
+// For more information on gogo.proto, see:
+// https://github.com/gogo/protobuf/blob/master/extensions.md
+// import "github.com/gogo/protobuf/gogoproto/gogo.proto";
+
 // This file is copied from http://github.com/tendermint/abci
-
-//----------------------------------------
-// Code types
-
-enum CodeType {
-	OK                    = 0;
-
-	// General response codes, 0 ~ 99
-	InternalError         = 1;
-	EncodingError         = 2;
-	BadNonce              = 3;
-	Unauthorized          = 4;
-	InsufficientFunds     = 5;
-	UnknownRequest        = 6;
-
-	// Reserved for basecoin, 100 ~ 199
-	BaseDuplicateAddress  = 101;
-	BaseEncodingError     = 102;
-	BaseInsufficientFees  = 103;
-	BaseInsufficientFunds = 104;
-	BaseInsufficientGasPrice = 105;
-	BaseInvalidInput      = 106;
-	BaseInvalidOutput     = 107;
-	BaseInvalidPubKey     = 108;
-	BaseInvalidSequence   = 109;
-	BaseInvalidSignature  = 110;
-	BaseUnknownAddress    = 111;
-	BaseUnknownPubKey     = 112;
-	BaseUnknownPlugin     = 113;
-
-	// Reserved for governance, 200 ~ 299
-	GovUnknownEntity      = 201;
-	GovUnknownGroup       = 202;
-	GovUnknownProposal    = 203;
-	GovDuplicateGroup     = 204;
-	GovDuplicateMember    = 205;
-	GovDuplicateProposal  = 206;
-	GovDuplicateVote      = 207;
-	GovInvalidMember      = 208;
-	GovInvalidVote        = 209;
-	GovInvalidVotingPower = 210;
-
-}
 
 //----------------------------------------
 // Request types
 
 message Request {
-	oneof value{
-		RequestEcho echo = 1;
-		RequestFlush flush = 2;
-		RequestInfo info = 3;
-		RequestSetOption set_option = 4;
-		RequestDeliverTx deliver_tx = 5;
-		RequestCheckTx check_tx = 6;
-		RequestCommit commit = 7;
-		RequestQuery query = 8;
-		RequestInitChain init_chain = 9;
-		RequestBeginBlock begin_block = 10;
-		RequestEndBlock end_block = 11;
-	}
+  oneof value {
+    RequestEcho echo = 2;
+    RequestFlush flush = 3;
+    RequestInfo info = 4;
+    RequestSetOption set_option = 5;
+    RequestInitChain init_chain = 6;
+    RequestQuery query = 7;
+    RequestBeginBlock begin_block = 8;
+    RequestCheckTx check_tx = 9;
+    RequestDeliverTx deliver_tx = 19;
+    RequestEndBlock end_block = 11;
+    RequestCommit commit = 12;
+  }
 }
 
 message RequestEcho {
-	string message = 1;
+  string message = 1;
 }
 
 message RequestFlush {
 }
 
 message RequestInfo {
+  string version = 1;
 }
 
-message RequestSetOption{
-	string key = 1;
-	string value = 2;
+message RequestSetOption {
+  string key = 1;
+  string value = 2;
 }
 
-message RequestDeliverTx{
-	bytes tx = 1;
-}
-
-message RequestCheckTx{
-	bytes tx = 1;
+message RequestInitChain {
+  repeated Validator validators = 1;
 }
 
 message RequestQuery{
-	bytes data = 1;
-	string path = 2;
-	uint64 height = 3;
-	bool prove = 4;
+  bytes data = 1;
+  string path = 2;
+  int64 height = 3;
+  bool prove = 4;
 }
 
-message RequestCommit{
+message RequestBeginBlock {
+  bytes hash = 1;
+  Header header = 2;
+  repeated int32 absent_validators = 3;
+  repeated Evidence byzantine_validators = 4;
 }
 
-message RequestInitChain{
-	repeated Validator validators = 1;
+message RequestCheckTx {
+  bytes tx = 1;
 }
 
-message RequestBeginBlock{
-	bytes hash = 1;
-	Header header = 2;
+message RequestDeliverTx {
+  bytes tx = 1;
 }
 
 message RequestEndBlock{
-	uint64 height = 1;
+  int64 height = 1;
+}
+
+message RequestCommit {
 }
 
 //----------------------------------------
 // Response types
 
-
 message Response {
-	oneof value{
-		ResponseException exception = 1;
-		ResponseEcho echo = 2;
-		ResponseFlush flush = 3;
-		ResponseInfo info = 4;
-		ResponseSetOption set_option = 5;
-		ResponseDeliverTx deliver_tx = 6;
-		ResponseCheckTx check_tx = 7;
-		ResponseCommit commit = 8;
-		ResponseQuery query = 9;
-		ResponseInitChain init_chain = 10;
-		ResponseBeginBlock begin_block = 11;
-		ResponseEndBlock end_block = 12;
-	}
+  oneof value {
+    ResponseException exception = 1;
+    ResponseEcho echo = 2;
+    ResponseFlush flush = 3;
+    ResponseInfo info = 4;
+    ResponseSetOption set_option = 5;
+    ResponseInitChain init_chain = 6;
+    ResponseQuery query = 7;
+    ResponseBeginBlock begin_block = 8;
+    ResponseCheckTx check_tx = 9;
+    ResponseDeliverTx deliver_tx = 10;
+    ResponseEndBlock end_block = 11;
+    ResponseCommit commit = 12;
+  }
 }
 
-message ResponseException{
-	string error = 1;
+message ResponseException {
+  string error = 1;
 }
 
 message ResponseEcho {
-	string message = 1;
+  string message = 1;
 }
 
-message ResponseFlush{
+message ResponseFlush {
 }
 
 message ResponseInfo {
-	string data = 1;
-	string version = 2;
-	uint64 last_block_height = 3;
-	bytes last_block_app_hash = 4;
+  string data = 1;
+  string version = 2;
+  int64 last_block_height = 3;
+  bytes last_block_app_hash = 4;
 }
 
-message ResponseSetOption{
-	string log = 1;
+message ResponseSetOption {
+  uint32 code = 1;
+  string log  = 2;
 }
 
-message ResponseDeliverTx{
-	CodeType          code        = 1;
-	bytes             data        = 2;
-	string            log         = 3;
+message ResponseInitChain {
 }
 
-message ResponseCheckTx{
-	CodeType          code        = 1;
-	bytes             data        = 2;
-	string            log         = 3;
+message ResponseQuery {
+  uint32 code = 1;
+  int64 index = 2;
+  bytes key = 3;
+  bytes value = 4;
+  bytes proof = 5;
+  int64 height = 6;
+  string log = 7;
 }
 
-message ResponseQuery{
-	CodeType          code        = 1;
-	int64             index       = 2;
-	bytes             key         = 3;
-	bytes             value       = 4;
-	bytes             proof       = 5;
-	uint64            height      = 6;
-	string            log         = 7;
+message ResponseBeginBlock {
 }
 
-message ResponseCommit{
-	CodeType          code        = 1;
-	bytes             data        = 2;
-	string            log         = 3;
+message ResponseCheckTx {
+  uint32 code = 1;
+  bytes data = 2;
+  string log = 3;
+  int64 gas = 4;
+  int64 fee = 5;
 }
 
-
-message ResponseInitChain{
+message ResponseDeliverTx {
+  uint32 code = 1;
+  bytes data = 2;
+  string log = 3;
+  repeated KVPair tags = 4;
 }
 
-message ResponseBeginBlock{
+message ResponseEndBlock {
+  repeated Validator validator_updates = 1;
+  ConsensusParams consensus_param_updates = 2;
 }
 
-message ResponseEndBlock{
-	repeated Validator diffs = 1;
+message ResponseCommit {
+  uint32 code = 1;
+  bytes data = 2;
+  string log = 3;
+}
+
+//----------------------------------------
+// Misc.
+
+// ConsensusParams contains all consensus-relevant parameters
+// that can be adjusted by the abci app
+message ConsensusParams {
+  BlockSize block_size = 1;
+  TxSize tx_size = 2;
+  BlockGossip block_gossip = 3;
+}
+
+// BlockSize contain limits on the block size.
+message BlockSize {
+  int32 max_bytes = 1;
+  int32 max_txs = 2;
+  int64 max_gas = 3;
+}
+
+// TxSize contain limits on the tx size.
+message TxSize{
+  int32 max_bytes = 1;
+  int64 max_gas = 2;
+}
+
+// BlockGossip determine consensus critical
+// elements of how blocks are gossiped
+message BlockGossip {
+  // Note: must not be 0
+  int32 block_part_size_bytes = 1;
 }
 
 //----------------------------------------
 // Blockchain Types
 
 message Header {
-	string chain_id = 1;
-	uint64 height = 2;
-	uint64 time = 3;
-	uint64 num_txs = 4;
-	BlockID last_block_id = 5;
-	bytes last_commit_hash = 6;
-	bytes data_hash = 7;
-	bytes validators_hash = 8;
-	bytes app_hash = 9;
+  string chain_id = 1;
+  int64 height = 2;
+  int64 time = 3;
+  int32 num_txs = 4;
+  BlockID last_block_id = 5;
+  bytes last_commit_hash = 6;
+  bytes data_hash = 7;
+  bytes validators_hash = 8;
+  bytes app_hash = 9;
 }
 
 message BlockID {
-	bytes hash = 1;
-	PartSetHeader parts = 2;
+  bytes hash = 1;
+  PartSetHeader parts = 2;
 }
 
 message PartSetHeader {
-	uint64 total = 1;
-	bytes hash = 2;
+  int32 total = 1;
+  bytes hash = 2;
 }
 
 message Validator {
-	bytes pubKey = 1;
-	uint64 power = 2;
+  bytes pub_key = 1;
+  int64 power = 2;
+}
+
+message Evidence {
+  bytes pub_key = 1;
+  int64 height = 2;
+}
+
+//----------------------------------------
+// Abstract types
+
+message KVPair {
+  string key = 1;
+  enum Type {
+    STRING = 0;
+    INT = 1;
+  }
+  Type value_type = 2;
+  string value_string = 3;
+  int64 value_int = 4;
 }
 
 //----------------------------------------
 // Service Definition
 
 service ABCIApplication {
-	rpc Echo(RequestEcho) returns (ResponseEcho) ;
-	rpc Flush(RequestFlush) returns (ResponseFlush);
-	rpc Info(RequestInfo) returns (ResponseInfo);
-	rpc SetOption(RequestSetOption) returns (ResponseSetOption);
-	rpc DeliverTx(RequestDeliverTx) returns (ResponseDeliverTx);
-	rpc CheckTx(RequestCheckTx) returns (ResponseCheckTx);
-	rpc Query(RequestQuery) returns (ResponseQuery);
-	rpc Commit(RequestCommit) returns (ResponseCommit);
-	rpc InitChain(RequestInitChain) returns (ResponseInitChain);
-	rpc BeginBlock(RequestBeginBlock) returns (ResponseBeginBlock);
-	rpc EndBlock(RequestEndBlock) returns (ResponseEndBlock);
+  rpc Echo(RequestEcho) returns (ResponseEcho) ;
+  rpc Flush(RequestFlush) returns (ResponseFlush);
+  rpc Info(RequestInfo) returns (ResponseInfo);
+  rpc SetOption(RequestSetOption) returns (ResponseSetOption);
+  rpc DeliverTx(RequestDeliverTx) returns (ResponseDeliverTx);
+  rpc CheckTx(RequestCheckTx) returns (ResponseCheckTx);
+  rpc Query(RequestQuery) returns (ResponseQuery);
+  rpc Commit(RequestCommit) returns (ResponseCommit);
+  rpc InitChain(RequestInitChain) returns (ResponseInitChain);
+  rpc BeginBlock(RequestBeginBlock) returns (ResponseBeginBlock);
+  rpc EndBlock(RequestEndBlock) returns (ResponseEndBlock);
 }

--- a/src/Proto/Network/ABCI/Types.hs
+++ b/src/Proto/Network/ABCI/Types.hs
@@ -1,12 +1,13 @@
-{- This file was auto-generated from Network/ABCI/types.proto by the proto-lens-protoc program. -}
+{- This file was auto-generated from src/Network/ABCI/types.proto by the proto-lens-protoc program. -}
 {-# LANGUAGE ScopedTypeVariables, DataKinds, TypeFamilies,
   UndecidableInstances, MultiParamTypeClasses, FlexibleContexts,
-  FlexibleInstances, PatternSynonyms, MagicHash #-}
+  FlexibleInstances, PatternSynonyms, MagicHash, NoImplicitPrelude
+  #-}
 {-# OPTIONS_GHC -fno-warn-unused-imports#-}
 module Proto.Network.ABCI.Types where
-import qualified Prelude
-import qualified Data.Int
-import qualified Data.Word
+import qualified Data.ProtoLens.Reexport.Prelude as Prelude
+import qualified Data.ProtoLens.Reexport.Data.Int as Data.Int
+import qualified Data.ProtoLens.Reexport.Data.Word as Data.Word
 import qualified Data.ProtoLens.Reexport.Data.ProtoLens
        as Data.ProtoLens
 import qualified
@@ -24,25 +25,67 @@ import qualified Data.ProtoLens.Reexport.Data.ByteString
        as Data.ByteString
 import qualified Data.ProtoLens.Reexport.Lens.Labels as Lens.Labels
 
+data BlockGossip = BlockGossip{_BlockGossip'blockPartSizeBytes ::
+                               !Data.Int.Int32}
+                 deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
+
+instance (a ~ Data.Int.Int32, b ~ Data.Int.Int32,
+          Prelude.Functor f) =>
+         Lens.Labels.HasLens "blockPartSizeBytes" f BlockGossip BlockGossip
+           a
+           b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _BlockGossip'blockPartSizeBytes
+                 (\ x__ y__ -> x__{_BlockGossip'blockPartSizeBytes = y__}))
+              Prelude.id
+
+instance Data.Default.Class.Default BlockGossip where
+        def
+          = BlockGossip{_BlockGossip'blockPartSizeBytes =
+                          Data.ProtoLens.fieldDefault}
+
+instance Data.ProtoLens.Message BlockGossip where
+        descriptor
+          = let blockPartSizeBytes__field_descriptor
+                  = Data.ProtoLens.FieldDescriptor "block_part_size_bytes"
+                      (Data.ProtoLens.Int32Field ::
+                         Data.ProtoLens.FieldTypeDescriptor Data.Int.Int32)
+                      (Data.ProtoLens.PlainField Data.ProtoLens.Optional
+                         blockPartSizeBytes)
+                      :: Data.ProtoLens.FieldDescriptor BlockGossip
+              in
+              Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "types.BlockGossip")
+                (Data.Map.fromList
+                   [(Data.ProtoLens.Tag 1, blockPartSizeBytes__field_descriptor)])
+                (Data.Map.fromList
+                   [("block_part_size_bytes", blockPartSizeBytes__field_descriptor)])
+
 data BlockID = BlockID{_BlockID'hash ::
                        !Data.ByteString.ByteString,
                        _BlockID'parts :: !(Prelude.Maybe PartSetHeader)}
-             deriving (Prelude.Show, Prelude.Eq)
+             deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
 instance (a ~ Data.ByteString.ByteString,
           b ~ Data.ByteString.ByteString, Prelude.Functor f) =>
          Lens.Labels.HasLens "hash" f BlockID BlockID a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _BlockID'hash
-              (\ x__ y__ -> x__{_BlockID'hash = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _BlockID'hash
+                 (\ x__ y__ -> x__{_BlockID'hash = y__}))
+              Prelude.id
 
 instance (a ~ PartSetHeader, b ~ PartSetHeader,
           Prelude.Functor f) =>
          Lens.Labels.HasLens "parts" f BlockID BlockID a b
          where
         lensOf _
-          = (Prelude..) maybe'parts
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _BlockID'parts
+                 (\ x__ y__ -> x__{_BlockID'parts = y__}))
               (Data.ProtoLens.maybeLens Data.Default.Class.def)
 
 instance (a ~ Prelude.Maybe PartSetHeader,
@@ -50,8 +93,10 @@ instance (a ~ Prelude.Maybe PartSetHeader,
          Lens.Labels.HasLens "maybe'parts" f BlockID BlockID a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _BlockID'parts
-              (\ x__ y__ -> x__{_BlockID'parts = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _BlockID'parts
+                 (\ x__ y__ -> x__{_BlockID'parts = y__}))
+              Prelude.id
 
 instance Data.Default.Class.Default BlockID where
         def
@@ -73,7 +118,7 @@ instance Data.ProtoLens.Message BlockID where
                       (Data.ProtoLens.OptionalField maybe'parts)
                       :: Data.ProtoLens.FieldDescriptor BlockID
               in
-              Data.ProtoLens.MessageDescriptor
+              Data.ProtoLens.MessageDescriptor (Data.Text.pack "types.BlockID")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 1, hash__field_descriptor),
                     (Data.ProtoLens.Tag 2, parts__field_descriptor)])
@@ -81,300 +126,301 @@ instance Data.ProtoLens.Message BlockID where
                    [("hash", hash__field_descriptor),
                     ("parts", parts__field_descriptor)])
 
-data CodeType = OK
-              | InternalError
-              | EncodingError
-              | BadNonce
-              | Unauthorized
-              | InsufficientFunds
-              | UnknownRequest
-              | BaseDuplicateAddress
-              | BaseEncodingError
-              | BaseInsufficientFees
-              | BaseInsufficientFunds
-              | BaseInsufficientGasPrice
-              | BaseInvalidInput
-              | BaseInvalidOutput
-              | BaseInvalidPubKey
-              | BaseInvalidSequence
-              | BaseInvalidSignature
-              | BaseUnknownAddress
-              | BaseUnknownPubKey
-              | BaseUnknownPlugin
-              | GovUnknownEntity
-              | GovUnknownGroup
-              | GovUnknownProposal
-              | GovDuplicateGroup
-              | GovDuplicateMember
-              | GovDuplicateProposal
-              | GovDuplicateVote
-              | GovInvalidMember
-              | GovInvalidVote
-              | GovInvalidVotingPower
-              deriving (Prelude.Show, Prelude.Eq)
+data BlockSize = BlockSize{_BlockSize'maxBytes :: !Data.Int.Int32,
+                           _BlockSize'maxTxs :: !Data.Int.Int32,
+                           _BlockSize'maxGas :: !Data.Int.Int64}
+               deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
-instance Data.Default.Class.Default CodeType where
-        def = OK
-
-instance Data.ProtoLens.FieldDefault CodeType where
-        fieldDefault = OK
-
-instance Data.ProtoLens.MessageEnum CodeType where
-        maybeToEnum 0 = Prelude.Just OK
-        maybeToEnum 1 = Prelude.Just InternalError
-        maybeToEnum 2 = Prelude.Just EncodingError
-        maybeToEnum 3 = Prelude.Just BadNonce
-        maybeToEnum 4 = Prelude.Just Unauthorized
-        maybeToEnum 5 = Prelude.Just InsufficientFunds
-        maybeToEnum 6 = Prelude.Just UnknownRequest
-        maybeToEnum 101 = Prelude.Just BaseDuplicateAddress
-        maybeToEnum 102 = Prelude.Just BaseEncodingError
-        maybeToEnum 103 = Prelude.Just BaseInsufficientFees
-        maybeToEnum 104 = Prelude.Just BaseInsufficientFunds
-        maybeToEnum 105 = Prelude.Just BaseInsufficientGasPrice
-        maybeToEnum 106 = Prelude.Just BaseInvalidInput
-        maybeToEnum 107 = Prelude.Just BaseInvalidOutput
-        maybeToEnum 108 = Prelude.Just BaseInvalidPubKey
-        maybeToEnum 109 = Prelude.Just BaseInvalidSequence
-        maybeToEnum 110 = Prelude.Just BaseInvalidSignature
-        maybeToEnum 111 = Prelude.Just BaseUnknownAddress
-        maybeToEnum 112 = Prelude.Just BaseUnknownPubKey
-        maybeToEnum 113 = Prelude.Just BaseUnknownPlugin
-        maybeToEnum 201 = Prelude.Just GovUnknownEntity
-        maybeToEnum 202 = Prelude.Just GovUnknownGroup
-        maybeToEnum 203 = Prelude.Just GovUnknownProposal
-        maybeToEnum 204 = Prelude.Just GovDuplicateGroup
-        maybeToEnum 205 = Prelude.Just GovDuplicateMember
-        maybeToEnum 206 = Prelude.Just GovDuplicateProposal
-        maybeToEnum 207 = Prelude.Just GovDuplicateVote
-        maybeToEnum 208 = Prelude.Just GovInvalidMember
-        maybeToEnum 209 = Prelude.Just GovInvalidVote
-        maybeToEnum 210 = Prelude.Just GovInvalidVotingPower
-        maybeToEnum _ = Prelude.Nothing
-        showEnum OK = "OK"
-        showEnum InternalError = "InternalError"
-        showEnum EncodingError = "EncodingError"
-        showEnum BadNonce = "BadNonce"
-        showEnum Unauthorized = "Unauthorized"
-        showEnum InsufficientFunds = "InsufficientFunds"
-        showEnum UnknownRequest = "UnknownRequest"
-        showEnum BaseDuplicateAddress = "BaseDuplicateAddress"
-        showEnum BaseEncodingError = "BaseEncodingError"
-        showEnum BaseInsufficientFees = "BaseInsufficientFees"
-        showEnum BaseInsufficientFunds = "BaseInsufficientFunds"
-        showEnum BaseInsufficientGasPrice = "BaseInsufficientGasPrice"
-        showEnum BaseInvalidInput = "BaseInvalidInput"
-        showEnum BaseInvalidOutput = "BaseInvalidOutput"
-        showEnum BaseInvalidPubKey = "BaseInvalidPubKey"
-        showEnum BaseInvalidSequence = "BaseInvalidSequence"
-        showEnum BaseInvalidSignature = "BaseInvalidSignature"
-        showEnum BaseUnknownAddress = "BaseUnknownAddress"
-        showEnum BaseUnknownPubKey = "BaseUnknownPubKey"
-        showEnum BaseUnknownPlugin = "BaseUnknownPlugin"
-        showEnum GovUnknownEntity = "GovUnknownEntity"
-        showEnum GovUnknownGroup = "GovUnknownGroup"
-        showEnum GovUnknownProposal = "GovUnknownProposal"
-        showEnum GovDuplicateGroup = "GovDuplicateGroup"
-        showEnum GovDuplicateMember = "GovDuplicateMember"
-        showEnum GovDuplicateProposal = "GovDuplicateProposal"
-        showEnum GovDuplicateVote = "GovDuplicateVote"
-        showEnum GovInvalidMember = "GovInvalidMember"
-        showEnum GovInvalidVote = "GovInvalidVote"
-        showEnum GovInvalidVotingPower = "GovInvalidVotingPower"
-        readEnum "OK" = Prelude.Just OK
-        readEnum "InternalError" = Prelude.Just InternalError
-        readEnum "EncodingError" = Prelude.Just EncodingError
-        readEnum "BadNonce" = Prelude.Just BadNonce
-        readEnum "Unauthorized" = Prelude.Just Unauthorized
-        readEnum "InsufficientFunds" = Prelude.Just InsufficientFunds
-        readEnum "UnknownRequest" = Prelude.Just UnknownRequest
-        readEnum "BaseDuplicateAddress" = Prelude.Just BaseDuplicateAddress
-        readEnum "BaseEncodingError" = Prelude.Just BaseEncodingError
-        readEnum "BaseInsufficientFees" = Prelude.Just BaseInsufficientFees
-        readEnum "BaseInsufficientFunds"
-          = Prelude.Just BaseInsufficientFunds
-        readEnum "BaseInsufficientGasPrice"
-          = Prelude.Just BaseInsufficientGasPrice
-        readEnum "BaseInvalidInput" = Prelude.Just BaseInvalidInput
-        readEnum "BaseInvalidOutput" = Prelude.Just BaseInvalidOutput
-        readEnum "BaseInvalidPubKey" = Prelude.Just BaseInvalidPubKey
-        readEnum "BaseInvalidSequence" = Prelude.Just BaseInvalidSequence
-        readEnum "BaseInvalidSignature" = Prelude.Just BaseInvalidSignature
-        readEnum "BaseUnknownAddress" = Prelude.Just BaseUnknownAddress
-        readEnum "BaseUnknownPubKey" = Prelude.Just BaseUnknownPubKey
-        readEnum "BaseUnknownPlugin" = Prelude.Just BaseUnknownPlugin
-        readEnum "GovUnknownEntity" = Prelude.Just GovUnknownEntity
-        readEnum "GovUnknownGroup" = Prelude.Just GovUnknownGroup
-        readEnum "GovUnknownProposal" = Prelude.Just GovUnknownProposal
-        readEnum "GovDuplicateGroup" = Prelude.Just GovDuplicateGroup
-        readEnum "GovDuplicateMember" = Prelude.Just GovDuplicateMember
-        readEnum "GovDuplicateProposal" = Prelude.Just GovDuplicateProposal
-        readEnum "GovDuplicateVote" = Prelude.Just GovDuplicateVote
-        readEnum "GovInvalidMember" = Prelude.Just GovInvalidMember
-        readEnum "GovInvalidVote" = Prelude.Just GovInvalidVote
-        readEnum "GovInvalidVotingPower"
-          = Prelude.Just GovInvalidVotingPower
-        readEnum _ = Prelude.Nothing
-
-instance Prelude.Enum CodeType where
-        toEnum k__
-          = Prelude.maybe
-              (Prelude.error
-                 ((Prelude.++) "toEnum: unknown value for enum CodeType: "
-                    (Prelude.show k__)))
+instance (a ~ Data.Int.Int32, b ~ Data.Int.Int32,
+          Prelude.Functor f) =>
+         Lens.Labels.HasLens "maxBytes" f BlockSize BlockSize a b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _BlockSize'maxBytes
+                 (\ x__ y__ -> x__{_BlockSize'maxBytes = y__}))
               Prelude.id
-              (Data.ProtoLens.maybeToEnum k__)
-        fromEnum OK = 0
-        fromEnum InternalError = 1
-        fromEnum EncodingError = 2
-        fromEnum BadNonce = 3
-        fromEnum Unauthorized = 4
-        fromEnum InsufficientFunds = 5
-        fromEnum UnknownRequest = 6
-        fromEnum BaseDuplicateAddress = 101
-        fromEnum BaseEncodingError = 102
-        fromEnum BaseInsufficientFees = 103
-        fromEnum BaseInsufficientFunds = 104
-        fromEnum BaseInsufficientGasPrice = 105
-        fromEnum BaseInvalidInput = 106
-        fromEnum BaseInvalidOutput = 107
-        fromEnum BaseInvalidPubKey = 108
-        fromEnum BaseInvalidSequence = 109
-        fromEnum BaseInvalidSignature = 110
-        fromEnum BaseUnknownAddress = 111
-        fromEnum BaseUnknownPubKey = 112
-        fromEnum BaseUnknownPlugin = 113
-        fromEnum GovUnknownEntity = 201
-        fromEnum GovUnknownGroup = 202
-        fromEnum GovUnknownProposal = 203
-        fromEnum GovDuplicateGroup = 204
-        fromEnum GovDuplicateMember = 205
-        fromEnum GovDuplicateProposal = 206
-        fromEnum GovDuplicateVote = 207
-        fromEnum GovInvalidMember = 208
-        fromEnum GovInvalidVote = 209
-        fromEnum GovInvalidVotingPower = 210
-        succ GovInvalidVotingPower
-          = Prelude.error
-              "CodeType.succ: bad argument GovInvalidVotingPower. This value would be out of bounds."
-        succ OK = InternalError
-        succ InternalError = EncodingError
-        succ EncodingError = BadNonce
-        succ BadNonce = Unauthorized
-        succ Unauthorized = InsufficientFunds
-        succ InsufficientFunds = UnknownRequest
-        succ UnknownRequest = BaseDuplicateAddress
-        succ BaseDuplicateAddress = BaseEncodingError
-        succ BaseEncodingError = BaseInsufficientFees
-        succ BaseInsufficientFees = BaseInsufficientFunds
-        succ BaseInsufficientFunds = BaseInsufficientGasPrice
-        succ BaseInsufficientGasPrice = BaseInvalidInput
-        succ BaseInvalidInput = BaseInvalidOutput
-        succ BaseInvalidOutput = BaseInvalidPubKey
-        succ BaseInvalidPubKey = BaseInvalidSequence
-        succ BaseInvalidSequence = BaseInvalidSignature
-        succ BaseInvalidSignature = BaseUnknownAddress
-        succ BaseUnknownAddress = BaseUnknownPubKey
-        succ BaseUnknownPubKey = BaseUnknownPlugin
-        succ BaseUnknownPlugin = GovUnknownEntity
-        succ GovUnknownEntity = GovUnknownGroup
-        succ GovUnknownGroup = GovUnknownProposal
-        succ GovUnknownProposal = GovDuplicateGroup
-        succ GovDuplicateGroup = GovDuplicateMember
-        succ GovDuplicateMember = GovDuplicateProposal
-        succ GovDuplicateProposal = GovDuplicateVote
-        succ GovDuplicateVote = GovInvalidMember
-        succ GovInvalidMember = GovInvalidVote
-        succ GovInvalidVote = GovInvalidVotingPower
-        pred OK
-          = Prelude.error
-              "CodeType.pred: bad argument OK. This value would be out of bounds."
-        pred InternalError = OK
-        pred EncodingError = InternalError
-        pred BadNonce = EncodingError
-        pred Unauthorized = BadNonce
-        pred InsufficientFunds = Unauthorized
-        pred UnknownRequest = InsufficientFunds
-        pred BaseDuplicateAddress = UnknownRequest
-        pred BaseEncodingError = BaseDuplicateAddress
-        pred BaseInsufficientFees = BaseEncodingError
-        pred BaseInsufficientFunds = BaseInsufficientFees
-        pred BaseInsufficientGasPrice = BaseInsufficientFunds
-        pred BaseInvalidInput = BaseInsufficientGasPrice
-        pred BaseInvalidOutput = BaseInvalidInput
-        pred BaseInvalidPubKey = BaseInvalidOutput
-        pred BaseInvalidSequence = BaseInvalidPubKey
-        pred BaseInvalidSignature = BaseInvalidSequence
-        pred BaseUnknownAddress = BaseInvalidSignature
-        pred BaseUnknownPubKey = BaseUnknownAddress
-        pred BaseUnknownPlugin = BaseUnknownPubKey
-        pred GovUnknownEntity = BaseUnknownPlugin
-        pred GovUnknownGroup = GovUnknownEntity
-        pred GovUnknownProposal = GovUnknownGroup
-        pred GovDuplicateGroup = GovUnknownProposal
-        pred GovDuplicateMember = GovDuplicateGroup
-        pred GovDuplicateProposal = GovDuplicateMember
-        pred GovDuplicateVote = GovDuplicateProposal
-        pred GovInvalidMember = GovDuplicateVote
-        pred GovInvalidVote = GovInvalidMember
-        pred GovInvalidVotingPower = GovInvalidVote
-        enumFrom = Data.ProtoLens.Message.Enum.messageEnumFrom
-        enumFromTo = Data.ProtoLens.Message.Enum.messageEnumFromTo
-        enumFromThen = Data.ProtoLens.Message.Enum.messageEnumFromThen
-        enumFromThenTo = Data.ProtoLens.Message.Enum.messageEnumFromThenTo
 
-instance Prelude.Bounded CodeType where
-        minBound = OK
-        maxBound = GovInvalidVotingPower
+instance (a ~ Data.Int.Int32, b ~ Data.Int.Int32,
+          Prelude.Functor f) =>
+         Lens.Labels.HasLens "maxTxs" f BlockSize BlockSize a b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _BlockSize'maxTxs
+                 (\ x__ y__ -> x__{_BlockSize'maxTxs = y__}))
+              Prelude.id
+
+instance (a ~ Data.Int.Int64, b ~ Data.Int.Int64,
+          Prelude.Functor f) =>
+         Lens.Labels.HasLens "maxGas" f BlockSize BlockSize a b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _BlockSize'maxGas
+                 (\ x__ y__ -> x__{_BlockSize'maxGas = y__}))
+              Prelude.id
+
+instance Data.Default.Class.Default BlockSize where
+        def
+          = BlockSize{_BlockSize'maxBytes = Data.ProtoLens.fieldDefault,
+                      _BlockSize'maxTxs = Data.ProtoLens.fieldDefault,
+                      _BlockSize'maxGas = Data.ProtoLens.fieldDefault}
+
+instance Data.ProtoLens.Message BlockSize where
+        descriptor
+          = let maxBytes__field_descriptor
+                  = Data.ProtoLens.FieldDescriptor "max_bytes"
+                      (Data.ProtoLens.Int32Field ::
+                         Data.ProtoLens.FieldTypeDescriptor Data.Int.Int32)
+                      (Data.ProtoLens.PlainField Data.ProtoLens.Optional maxBytes)
+                      :: Data.ProtoLens.FieldDescriptor BlockSize
+                maxTxs__field_descriptor
+                  = Data.ProtoLens.FieldDescriptor "max_txs"
+                      (Data.ProtoLens.Int32Field ::
+                         Data.ProtoLens.FieldTypeDescriptor Data.Int.Int32)
+                      (Data.ProtoLens.PlainField Data.ProtoLens.Optional maxTxs)
+                      :: Data.ProtoLens.FieldDescriptor BlockSize
+                maxGas__field_descriptor
+                  = Data.ProtoLens.FieldDescriptor "max_gas"
+                      (Data.ProtoLens.Int64Field ::
+                         Data.ProtoLens.FieldTypeDescriptor Data.Int.Int64)
+                      (Data.ProtoLens.PlainField Data.ProtoLens.Optional maxGas)
+                      :: Data.ProtoLens.FieldDescriptor BlockSize
+              in
+              Data.ProtoLens.MessageDescriptor (Data.Text.pack "types.BlockSize")
+                (Data.Map.fromList
+                   [(Data.ProtoLens.Tag 1, maxBytes__field_descriptor),
+                    (Data.ProtoLens.Tag 2, maxTxs__field_descriptor),
+                    (Data.ProtoLens.Tag 3, maxGas__field_descriptor)])
+                (Data.Map.fromList
+                   [("max_bytes", maxBytes__field_descriptor),
+                    ("max_txs", maxTxs__field_descriptor),
+                    ("max_gas", maxGas__field_descriptor)])
+
+data ConsensusParams = ConsensusParams{_ConsensusParams'blockSize
+                                       :: !(Prelude.Maybe BlockSize),
+                                       _ConsensusParams'txSize :: !(Prelude.Maybe TxSize),
+                                       _ConsensusParams'blockGossip :: !(Prelude.Maybe BlockGossip)}
+                     deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
+
+instance (a ~ BlockSize, b ~ BlockSize, Prelude.Functor f) =>
+         Lens.Labels.HasLens "blockSize" f ConsensusParams ConsensusParams a
+           b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _ConsensusParams'blockSize
+                 (\ x__ y__ -> x__{_ConsensusParams'blockSize = y__}))
+              (Data.ProtoLens.maybeLens Data.Default.Class.def)
+
+instance (a ~ Prelude.Maybe BlockSize, b ~ Prelude.Maybe BlockSize,
+          Prelude.Functor f) =>
+         Lens.Labels.HasLens "maybe'blockSize" f ConsensusParams
+           ConsensusParams
+           a
+           b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _ConsensusParams'blockSize
+                 (\ x__ y__ -> x__{_ConsensusParams'blockSize = y__}))
+              Prelude.id
+
+instance (a ~ TxSize, b ~ TxSize, Prelude.Functor f) =>
+         Lens.Labels.HasLens "txSize" f ConsensusParams ConsensusParams a b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _ConsensusParams'txSize
+                 (\ x__ y__ -> x__{_ConsensusParams'txSize = y__}))
+              (Data.ProtoLens.maybeLens Data.Default.Class.def)
+
+instance (a ~ Prelude.Maybe TxSize, b ~ Prelude.Maybe TxSize,
+          Prelude.Functor f) =>
+         Lens.Labels.HasLens "maybe'txSize" f ConsensusParams
+           ConsensusParams
+           a
+           b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _ConsensusParams'txSize
+                 (\ x__ y__ -> x__{_ConsensusParams'txSize = y__}))
+              Prelude.id
+
+instance (a ~ BlockGossip, b ~ BlockGossip, Prelude.Functor f) =>
+         Lens.Labels.HasLens "blockGossip" f ConsensusParams ConsensusParams
+           a
+           b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _ConsensusParams'blockGossip
+                 (\ x__ y__ -> x__{_ConsensusParams'blockGossip = y__}))
+              (Data.ProtoLens.maybeLens Data.Default.Class.def)
+
+instance (a ~ Prelude.Maybe BlockGossip,
+          b ~ Prelude.Maybe BlockGossip, Prelude.Functor f) =>
+         Lens.Labels.HasLens "maybe'blockGossip" f ConsensusParams
+           ConsensusParams
+           a
+           b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _ConsensusParams'blockGossip
+                 (\ x__ y__ -> x__{_ConsensusParams'blockGossip = y__}))
+              Prelude.id
+
+instance Data.Default.Class.Default ConsensusParams where
+        def
+          = ConsensusParams{_ConsensusParams'blockSize = Prelude.Nothing,
+                            _ConsensusParams'txSize = Prelude.Nothing,
+                            _ConsensusParams'blockGossip = Prelude.Nothing}
+
+instance Data.ProtoLens.Message ConsensusParams where
+        descriptor
+          = let blockSize__field_descriptor
+                  = Data.ProtoLens.FieldDescriptor "block_size"
+                      (Data.ProtoLens.MessageField ::
+                         Data.ProtoLens.FieldTypeDescriptor BlockSize)
+                      (Data.ProtoLens.OptionalField maybe'blockSize)
+                      :: Data.ProtoLens.FieldDescriptor ConsensusParams
+                txSize__field_descriptor
+                  = Data.ProtoLens.FieldDescriptor "tx_size"
+                      (Data.ProtoLens.MessageField ::
+                         Data.ProtoLens.FieldTypeDescriptor TxSize)
+                      (Data.ProtoLens.OptionalField maybe'txSize)
+                      :: Data.ProtoLens.FieldDescriptor ConsensusParams
+                blockGossip__field_descriptor
+                  = Data.ProtoLens.FieldDescriptor "block_gossip"
+                      (Data.ProtoLens.MessageField ::
+                         Data.ProtoLens.FieldTypeDescriptor BlockGossip)
+                      (Data.ProtoLens.OptionalField maybe'blockGossip)
+                      :: Data.ProtoLens.FieldDescriptor ConsensusParams
+              in
+              Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "types.ConsensusParams")
+                (Data.Map.fromList
+                   [(Data.ProtoLens.Tag 1, blockSize__field_descriptor),
+                    (Data.ProtoLens.Tag 2, txSize__field_descriptor),
+                    (Data.ProtoLens.Tag 3, blockGossip__field_descriptor)])
+                (Data.Map.fromList
+                   [("block_size", blockSize__field_descriptor),
+                    ("tx_size", txSize__field_descriptor),
+                    ("block_gossip", blockGossip__field_descriptor)])
+
+data Evidence = Evidence{_Evidence'pubKey ::
+                         !Data.ByteString.ByteString,
+                         _Evidence'height :: !Data.Int.Int64}
+              deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
+
+instance (a ~ Data.ByteString.ByteString,
+          b ~ Data.ByteString.ByteString, Prelude.Functor f) =>
+         Lens.Labels.HasLens "pubKey" f Evidence Evidence a b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Evidence'pubKey
+                 (\ x__ y__ -> x__{_Evidence'pubKey = y__}))
+              Prelude.id
+
+instance (a ~ Data.Int.Int64, b ~ Data.Int.Int64,
+          Prelude.Functor f) =>
+         Lens.Labels.HasLens "height" f Evidence Evidence a b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Evidence'height
+                 (\ x__ y__ -> x__{_Evidence'height = y__}))
+              Prelude.id
+
+instance Data.Default.Class.Default Evidence where
+        def
+          = Evidence{_Evidence'pubKey = Data.ProtoLens.fieldDefault,
+                     _Evidence'height = Data.ProtoLens.fieldDefault}
+
+instance Data.ProtoLens.Message Evidence where
+        descriptor
+          = let pubKey__field_descriptor
+                  = Data.ProtoLens.FieldDescriptor "pub_key"
+                      (Data.ProtoLens.BytesField ::
+                         Data.ProtoLens.FieldTypeDescriptor Data.ByteString.ByteString)
+                      (Data.ProtoLens.PlainField Data.ProtoLens.Optional pubKey)
+                      :: Data.ProtoLens.FieldDescriptor Evidence
+                height__field_descriptor
+                  = Data.ProtoLens.FieldDescriptor "height"
+                      (Data.ProtoLens.Int64Field ::
+                         Data.ProtoLens.FieldTypeDescriptor Data.Int.Int64)
+                      (Data.ProtoLens.PlainField Data.ProtoLens.Optional height)
+                      :: Data.ProtoLens.FieldDescriptor Evidence
+              in
+              Data.ProtoLens.MessageDescriptor (Data.Text.pack "types.Evidence")
+                (Data.Map.fromList
+                   [(Data.ProtoLens.Tag 1, pubKey__field_descriptor),
+                    (Data.ProtoLens.Tag 2, height__field_descriptor)])
+                (Data.Map.fromList
+                   [("pub_key", pubKey__field_descriptor),
+                    ("height", height__field_descriptor)])
 
 data Header = Header{_Header'chainId :: !Data.Text.Text,
-                     _Header'height :: !Data.Word.Word64,
-                     _Header'time :: !Data.Word.Word64,
-                     _Header'numTxs :: !Data.Word.Word64,
+                     _Header'height :: !Data.Int.Int64, _Header'time :: !Data.Int.Int64,
+                     _Header'numTxs :: !Data.Int.Int32,
                      _Header'lastBlockId :: !(Prelude.Maybe BlockID),
                      _Header'lastCommitHash :: !Data.ByteString.ByteString,
                      _Header'dataHash :: !Data.ByteString.ByteString,
                      _Header'validatorsHash :: !Data.ByteString.ByteString,
                      _Header'appHash :: !Data.ByteString.ByteString}
-            deriving (Prelude.Show, Prelude.Eq)
+            deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
 instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
           Prelude.Functor f) =>
          Lens.Labels.HasLens "chainId" f Header Header a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _Header'chainId
-              (\ x__ y__ -> x__{_Header'chainId = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Header'chainId
+                 (\ x__ y__ -> x__{_Header'chainId = y__}))
+              Prelude.id
 
-instance (a ~ Data.Word.Word64, b ~ Data.Word.Word64,
+instance (a ~ Data.Int.Int64, b ~ Data.Int.Int64,
           Prelude.Functor f) =>
          Lens.Labels.HasLens "height" f Header Header a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _Header'height
-              (\ x__ y__ -> x__{_Header'height = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Header'height
+                 (\ x__ y__ -> x__{_Header'height = y__}))
+              Prelude.id
 
-instance (a ~ Data.Word.Word64, b ~ Data.Word.Word64,
+instance (a ~ Data.Int.Int64, b ~ Data.Int.Int64,
           Prelude.Functor f) =>
          Lens.Labels.HasLens "time" f Header Header a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _Header'time
-              (\ x__ y__ -> x__{_Header'time = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Header'time
+                 (\ x__ y__ -> x__{_Header'time = y__}))
+              Prelude.id
 
-instance (a ~ Data.Word.Word64, b ~ Data.Word.Word64,
+instance (a ~ Data.Int.Int32, b ~ Data.Int.Int32,
           Prelude.Functor f) =>
          Lens.Labels.HasLens "numTxs" f Header Header a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _Header'numTxs
-              (\ x__ y__ -> x__{_Header'numTxs = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Header'numTxs
+                 (\ x__ y__ -> x__{_Header'numTxs = y__}))
+              Prelude.id
 
 instance (a ~ BlockID, b ~ BlockID, Prelude.Functor f) =>
          Lens.Labels.HasLens "lastBlockId" f Header Header a b
          where
         lensOf _
-          = (Prelude..) maybe'lastBlockId
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Header'lastBlockId
+                 (\ x__ y__ -> x__{_Header'lastBlockId = y__}))
               (Data.ProtoLens.maybeLens Data.Default.Class.def)
 
 instance (a ~ Prelude.Maybe BlockID, b ~ Prelude.Maybe BlockID,
@@ -382,40 +428,50 @@ instance (a ~ Prelude.Maybe BlockID, b ~ Prelude.Maybe BlockID,
          Lens.Labels.HasLens "maybe'lastBlockId" f Header Header a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _Header'lastBlockId
-              (\ x__ y__ -> x__{_Header'lastBlockId = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Header'lastBlockId
+                 (\ x__ y__ -> x__{_Header'lastBlockId = y__}))
+              Prelude.id
 
 instance (a ~ Data.ByteString.ByteString,
           b ~ Data.ByteString.ByteString, Prelude.Functor f) =>
          Lens.Labels.HasLens "lastCommitHash" f Header Header a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _Header'lastCommitHash
-              (\ x__ y__ -> x__{_Header'lastCommitHash = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Header'lastCommitHash
+                 (\ x__ y__ -> x__{_Header'lastCommitHash = y__}))
+              Prelude.id
 
 instance (a ~ Data.ByteString.ByteString,
           b ~ Data.ByteString.ByteString, Prelude.Functor f) =>
          Lens.Labels.HasLens "dataHash" f Header Header a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _Header'dataHash
-              (\ x__ y__ -> x__{_Header'dataHash = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Header'dataHash
+                 (\ x__ y__ -> x__{_Header'dataHash = y__}))
+              Prelude.id
 
 instance (a ~ Data.ByteString.ByteString,
           b ~ Data.ByteString.ByteString, Prelude.Functor f) =>
          Lens.Labels.HasLens "validatorsHash" f Header Header a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _Header'validatorsHash
-              (\ x__ y__ -> x__{_Header'validatorsHash = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Header'validatorsHash
+                 (\ x__ y__ -> x__{_Header'validatorsHash = y__}))
+              Prelude.id
 
 instance (a ~ Data.ByteString.ByteString,
           b ~ Data.ByteString.ByteString, Prelude.Functor f) =>
          Lens.Labels.HasLens "appHash" f Header Header a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _Header'appHash
-              (\ x__ y__ -> x__{_Header'appHash = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Header'appHash
+                 (\ x__ y__ -> x__{_Header'appHash = y__}))
+              Prelude.id
 
 instance Data.Default.Class.Default Header where
         def
@@ -439,20 +495,20 @@ instance Data.ProtoLens.Message Header where
                       :: Data.ProtoLens.FieldDescriptor Header
                 height__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "height"
-                      (Data.ProtoLens.UInt64Field ::
-                         Data.ProtoLens.FieldTypeDescriptor Data.Word.Word64)
+                      (Data.ProtoLens.Int64Field ::
+                         Data.ProtoLens.FieldTypeDescriptor Data.Int.Int64)
                       (Data.ProtoLens.PlainField Data.ProtoLens.Optional height)
                       :: Data.ProtoLens.FieldDescriptor Header
                 time__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "time"
-                      (Data.ProtoLens.UInt64Field ::
-                         Data.ProtoLens.FieldTypeDescriptor Data.Word.Word64)
+                      (Data.ProtoLens.Int64Field ::
+                         Data.ProtoLens.FieldTypeDescriptor Data.Int.Int64)
                       (Data.ProtoLens.PlainField Data.ProtoLens.Optional time)
                       :: Data.ProtoLens.FieldDescriptor Header
                 numTxs__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "num_txs"
-                      (Data.ProtoLens.UInt64Field ::
-                         Data.ProtoLens.FieldTypeDescriptor Data.Word.Word64)
+                      (Data.ProtoLens.Int32Field ::
+                         Data.ProtoLens.FieldTypeDescriptor Data.Int.Int32)
                       (Data.ProtoLens.PlainField Data.ProtoLens.Optional numTxs)
                       :: Data.ProtoLens.FieldDescriptor Header
                 lastBlockId__field_descriptor
@@ -486,7 +542,7 @@ instance Data.ProtoLens.Message Header where
                       (Data.ProtoLens.PlainField Data.ProtoLens.Optional appHash)
                       :: Data.ProtoLens.FieldDescriptor Header
               in
-              Data.ProtoLens.MessageDescriptor
+              Data.ProtoLens.MessageDescriptor (Data.Text.pack "types.Header")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 1, chainId__field_descriptor),
                     (Data.ProtoLens.Tag 2, height__field_descriptor),
@@ -508,26 +564,168 @@ instance Data.ProtoLens.Message Header where
                     ("validators_hash", validatorsHash__field_descriptor),
                     ("app_hash", appHash__field_descriptor)])
 
-data PartSetHeader = PartSetHeader{_PartSetHeader'total ::
-                                   !Data.Word.Word64,
-                                   _PartSetHeader'hash :: !Data.ByteString.ByteString}
-                   deriving (Prelude.Show, Prelude.Eq)
+data KVPair = KVPair{_KVPair'key :: !Data.Text.Text,
+                     _KVPair'valueType :: !KVPair'Type,
+                     _KVPair'valueString :: !Data.Text.Text,
+                     _KVPair'valueInt :: !Data.Int.Int64}
+            deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
-instance (a ~ Data.Word.Word64, b ~ Data.Word.Word64,
+instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
+          Prelude.Functor f) =>
+         Lens.Labels.HasLens "key" f KVPair KVPair a b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _KVPair'key
+                 (\ x__ y__ -> x__{_KVPair'key = y__}))
+              Prelude.id
+
+instance (a ~ KVPair'Type, b ~ KVPair'Type, Prelude.Functor f) =>
+         Lens.Labels.HasLens "valueType" f KVPair KVPair a b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _KVPair'valueType
+                 (\ x__ y__ -> x__{_KVPair'valueType = y__}))
+              Prelude.id
+
+instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
+          Prelude.Functor f) =>
+         Lens.Labels.HasLens "valueString" f KVPair KVPair a b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _KVPair'valueString
+                 (\ x__ y__ -> x__{_KVPair'valueString = y__}))
+              Prelude.id
+
+instance (a ~ Data.Int.Int64, b ~ Data.Int.Int64,
+          Prelude.Functor f) =>
+         Lens.Labels.HasLens "valueInt" f KVPair KVPair a b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _KVPair'valueInt
+                 (\ x__ y__ -> x__{_KVPair'valueInt = y__}))
+              Prelude.id
+
+instance Data.Default.Class.Default KVPair where
+        def
+          = KVPair{_KVPair'key = Data.ProtoLens.fieldDefault,
+                   _KVPair'valueType = Data.Default.Class.def,
+                   _KVPair'valueString = Data.ProtoLens.fieldDefault,
+                   _KVPair'valueInt = Data.ProtoLens.fieldDefault}
+
+instance Data.ProtoLens.Message KVPair where
+        descriptor
+          = let key__field_descriptor
+                  = Data.ProtoLens.FieldDescriptor "key"
+                      (Data.ProtoLens.StringField ::
+                         Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
+                      (Data.ProtoLens.PlainField Data.ProtoLens.Optional key)
+                      :: Data.ProtoLens.FieldDescriptor KVPair
+                valueType__field_descriptor
+                  = Data.ProtoLens.FieldDescriptor "value_type"
+                      (Data.ProtoLens.EnumField ::
+                         Data.ProtoLens.FieldTypeDescriptor KVPair'Type)
+                      (Data.ProtoLens.PlainField Data.ProtoLens.Optional valueType)
+                      :: Data.ProtoLens.FieldDescriptor KVPair
+                valueString__field_descriptor
+                  = Data.ProtoLens.FieldDescriptor "value_string"
+                      (Data.ProtoLens.StringField ::
+                         Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
+                      (Data.ProtoLens.PlainField Data.ProtoLens.Optional valueString)
+                      :: Data.ProtoLens.FieldDescriptor KVPair
+                valueInt__field_descriptor
+                  = Data.ProtoLens.FieldDescriptor "value_int"
+                      (Data.ProtoLens.Int64Field ::
+                         Data.ProtoLens.FieldTypeDescriptor Data.Int.Int64)
+                      (Data.ProtoLens.PlainField Data.ProtoLens.Optional valueInt)
+                      :: Data.ProtoLens.FieldDescriptor KVPair
+              in
+              Data.ProtoLens.MessageDescriptor (Data.Text.pack "types.KVPair")
+                (Data.Map.fromList
+                   [(Data.ProtoLens.Tag 1, key__field_descriptor),
+                    (Data.ProtoLens.Tag 2, valueType__field_descriptor),
+                    (Data.ProtoLens.Tag 3, valueString__field_descriptor),
+                    (Data.ProtoLens.Tag 4, valueInt__field_descriptor)])
+                (Data.Map.fromList
+                   [("key", key__field_descriptor),
+                    ("value_type", valueType__field_descriptor),
+                    ("value_string", valueString__field_descriptor),
+                    ("value_int", valueInt__field_descriptor)])
+
+data KVPair'Type = KVPair'STRING
+                 | KVPair'INT
+                 deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
+
+instance Data.Default.Class.Default KVPair'Type where
+        def = KVPair'STRING
+
+instance Data.ProtoLens.FieldDefault KVPair'Type where
+        fieldDefault = KVPair'STRING
+
+instance Data.ProtoLens.MessageEnum KVPair'Type where
+        maybeToEnum 0 = Prelude.Just KVPair'STRING
+        maybeToEnum 1 = Prelude.Just KVPair'INT
+        maybeToEnum _ = Prelude.Nothing
+        showEnum KVPair'STRING = "STRING"
+        showEnum KVPair'INT = "INT"
+        readEnum "STRING" = Prelude.Just KVPair'STRING
+        readEnum "INT" = Prelude.Just KVPair'INT
+        readEnum _ = Prelude.Nothing
+
+instance Prelude.Enum KVPair'Type where
+        toEnum k__
+          = Prelude.maybe
+              (Prelude.error
+                 ((Prelude.++) "toEnum: unknown value for enum Type: "
+                    (Prelude.show k__)))
+              Prelude.id
+              (Data.ProtoLens.maybeToEnum k__)
+        fromEnum KVPair'STRING = 0
+        fromEnum KVPair'INT = 1
+        succ KVPair'INT
+          = Prelude.error
+              "KVPair'Type.succ: bad argument KVPair'INT. This value would be out of bounds."
+        succ KVPair'STRING = KVPair'INT
+        pred KVPair'STRING
+          = Prelude.error
+              "KVPair'Type.pred: bad argument KVPair'STRING. This value would be out of bounds."
+        pred KVPair'INT = KVPair'STRING
+        enumFrom = Data.ProtoLens.Message.Enum.messageEnumFrom
+        enumFromTo = Data.ProtoLens.Message.Enum.messageEnumFromTo
+        enumFromThen = Data.ProtoLens.Message.Enum.messageEnumFromThen
+        enumFromThenTo = Data.ProtoLens.Message.Enum.messageEnumFromThenTo
+
+instance Prelude.Bounded KVPair'Type where
+        minBound = KVPair'STRING
+        maxBound = KVPair'INT
+
+data PartSetHeader = PartSetHeader{_PartSetHeader'total ::
+                                   !Data.Int.Int32,
+                                   _PartSetHeader'hash :: !Data.ByteString.ByteString}
+                   deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
+
+instance (a ~ Data.Int.Int32, b ~ Data.Int.Int32,
           Prelude.Functor f) =>
          Lens.Labels.HasLens "total" f PartSetHeader PartSetHeader a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _PartSetHeader'total
-              (\ x__ y__ -> x__{_PartSetHeader'total = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _PartSetHeader'total
+                 (\ x__ y__ -> x__{_PartSetHeader'total = y__}))
+              Prelude.id
 
 instance (a ~ Data.ByteString.ByteString,
           b ~ Data.ByteString.ByteString, Prelude.Functor f) =>
          Lens.Labels.HasLens "hash" f PartSetHeader PartSetHeader a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _PartSetHeader'hash
-              (\ x__ y__ -> x__{_PartSetHeader'hash = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _PartSetHeader'hash
+                 (\ x__ y__ -> x__{_PartSetHeader'hash = y__}))
+              Prelude.id
 
 instance Data.Default.Class.Default PartSetHeader where
         def
@@ -538,8 +736,8 @@ instance Data.ProtoLens.Message PartSetHeader where
         descriptor
           = let total__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "total"
-                      (Data.ProtoLens.UInt64Field ::
-                         Data.ProtoLens.FieldTypeDescriptor Data.Word.Word64)
+                      (Data.ProtoLens.Int32Field ::
+                         Data.ProtoLens.FieldTypeDescriptor Data.Int.Int32)
                       (Data.ProtoLens.PlainField Data.ProtoLens.Optional total)
                       :: Data.ProtoLens.FieldDescriptor PartSetHeader
                 hash__field_descriptor
@@ -550,6 +748,7 @@ instance Data.ProtoLens.Message PartSetHeader where
                       :: Data.ProtoLens.FieldDescriptor PartSetHeader
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "types.PartSetHeader")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 1, total__field_descriptor),
                     (Data.ProtoLens.Tag 2, hash__field_descriptor)])
@@ -557,204 +756,383 @@ instance Data.ProtoLens.Message PartSetHeader where
                    [("total", total__field_descriptor),
                     ("hash", hash__field_descriptor)])
 
-data Request = Request{_Request'echo ::
-                       !(Prelude.Maybe RequestEcho),
-                       _Request'flush :: !(Prelude.Maybe RequestFlush),
-                       _Request'info :: !(Prelude.Maybe RequestInfo),
-                       _Request'setOption :: !(Prelude.Maybe RequestSetOption),
-                       _Request'deliverTx :: !(Prelude.Maybe RequestDeliverTx),
-                       _Request'checkTx :: !(Prelude.Maybe RequestCheckTx),
-                       _Request'commit :: !(Prelude.Maybe RequestCommit),
-                       _Request'query :: !(Prelude.Maybe RequestQuery),
-                       _Request'initChain :: !(Prelude.Maybe RequestInitChain),
-                       _Request'beginBlock :: !(Prelude.Maybe RequestBeginBlock),
-                       _Request'endBlock :: !(Prelude.Maybe RequestEndBlock)}
-             deriving (Prelude.Show, Prelude.Eq)
+data Request = Request{_Request'value ::
+                       !(Prelude.Maybe Request'Value)}
+             deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
-instance (a ~ RequestEcho, b ~ RequestEcho, Prelude.Functor f) =>
-         Lens.Labels.HasLens "echo" f Request Request a b
+data Request'Value = Request'Echo !RequestEcho
+                   | Request'Flush !RequestFlush
+                   | Request'Info !RequestInfo
+                   | Request'SetOption !RequestSetOption
+                   | Request'InitChain !RequestInitChain
+                   | Request'Query !RequestQuery
+                   | Request'BeginBlock !RequestBeginBlock
+                   | Request'CheckTx !RequestCheckTx
+                   | Request'DeliverTx !RequestDeliverTx
+                   | Request'EndBlock !RequestEndBlock
+                   | Request'Commit !RequestCommit
+                   deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
+
+instance (a ~ Prelude.Maybe Request'Value,
+          b ~ Prelude.Maybe Request'Value, Prelude.Functor f) =>
+         Lens.Labels.HasLens "maybe'value" f Request Request a b
          where
         lensOf _
-          = (Prelude..) maybe'echo
-              (Data.ProtoLens.maybeLens Data.Default.Class.def)
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Request'value
+                 (\ x__ y__ -> x__{_Request'value = y__}))
+              Prelude.id
 
 instance (a ~ Prelude.Maybe RequestEcho,
           b ~ Prelude.Maybe RequestEcho, Prelude.Functor f) =>
          Lens.Labels.HasLens "maybe'echo" f Request Request a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _Request'echo
-              (\ x__ y__ -> x__{_Request'echo = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Request'value
+                 (\ x__ y__ -> x__{_Request'value = y__}))
+              (Lens.Family2.Unchecked.lens
+                 (\ x__ ->
+                    case x__ of
+                        Prelude.Just (Request'Echo x__val) -> Prelude.Just x__val
+                        _otherwise -> Prelude.Nothing)
+                 (\ _ y__ -> Prelude.fmap Request'Echo y__))
 
-instance (a ~ RequestFlush, b ~ RequestFlush, Prelude.Functor f) =>
-         Lens.Labels.HasLens "flush" f Request Request a b
+instance (a ~ RequestEcho, b ~ RequestEcho, Prelude.Functor f) =>
+         Lens.Labels.HasLens "echo" f Request Request a b
          where
         lensOf _
-          = (Prelude..) maybe'flush
-              (Data.ProtoLens.maybeLens Data.Default.Class.def)
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Request'value
+                 (\ x__ y__ -> x__{_Request'value = y__}))
+              ((Prelude..)
+                 (Lens.Family2.Unchecked.lens
+                    (\ x__ ->
+                       case x__ of
+                           Prelude.Just (Request'Echo x__val) -> Prelude.Just x__val
+                           _otherwise -> Prelude.Nothing)
+                    (\ _ y__ -> Prelude.fmap Request'Echo y__))
+                 (Data.ProtoLens.maybeLens Data.Default.Class.def))
 
 instance (a ~ Prelude.Maybe RequestFlush,
           b ~ Prelude.Maybe RequestFlush, Prelude.Functor f) =>
          Lens.Labels.HasLens "maybe'flush" f Request Request a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _Request'flush
-              (\ x__ y__ -> x__{_Request'flush = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Request'value
+                 (\ x__ y__ -> x__{_Request'value = y__}))
+              (Lens.Family2.Unchecked.lens
+                 (\ x__ ->
+                    case x__ of
+                        Prelude.Just (Request'Flush x__val) -> Prelude.Just x__val
+                        _otherwise -> Prelude.Nothing)
+                 (\ _ y__ -> Prelude.fmap Request'Flush y__))
 
-instance (a ~ RequestInfo, b ~ RequestInfo, Prelude.Functor f) =>
-         Lens.Labels.HasLens "info" f Request Request a b
+instance (a ~ RequestFlush, b ~ RequestFlush, Prelude.Functor f) =>
+         Lens.Labels.HasLens "flush" f Request Request a b
          where
         lensOf _
-          = (Prelude..) maybe'info
-              (Data.ProtoLens.maybeLens Data.Default.Class.def)
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Request'value
+                 (\ x__ y__ -> x__{_Request'value = y__}))
+              ((Prelude..)
+                 (Lens.Family2.Unchecked.lens
+                    (\ x__ ->
+                       case x__ of
+                           Prelude.Just (Request'Flush x__val) -> Prelude.Just x__val
+                           _otherwise -> Prelude.Nothing)
+                    (\ _ y__ -> Prelude.fmap Request'Flush y__))
+                 (Data.ProtoLens.maybeLens Data.Default.Class.def))
 
 instance (a ~ Prelude.Maybe RequestInfo,
           b ~ Prelude.Maybe RequestInfo, Prelude.Functor f) =>
          Lens.Labels.HasLens "maybe'info" f Request Request a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _Request'info
-              (\ x__ y__ -> x__{_Request'info = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Request'value
+                 (\ x__ y__ -> x__{_Request'value = y__}))
+              (Lens.Family2.Unchecked.lens
+                 (\ x__ ->
+                    case x__ of
+                        Prelude.Just (Request'Info x__val) -> Prelude.Just x__val
+                        _otherwise -> Prelude.Nothing)
+                 (\ _ y__ -> Prelude.fmap Request'Info y__))
 
-instance (a ~ RequestSetOption, b ~ RequestSetOption,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "setOption" f Request Request a b
+instance (a ~ RequestInfo, b ~ RequestInfo, Prelude.Functor f) =>
+         Lens.Labels.HasLens "info" f Request Request a b
          where
         lensOf _
-          = (Prelude..) maybe'setOption
-              (Data.ProtoLens.maybeLens Data.Default.Class.def)
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Request'value
+                 (\ x__ y__ -> x__{_Request'value = y__}))
+              ((Prelude..)
+                 (Lens.Family2.Unchecked.lens
+                    (\ x__ ->
+                       case x__ of
+                           Prelude.Just (Request'Info x__val) -> Prelude.Just x__val
+                           _otherwise -> Prelude.Nothing)
+                    (\ _ y__ -> Prelude.fmap Request'Info y__))
+                 (Data.ProtoLens.maybeLens Data.Default.Class.def))
 
 instance (a ~ Prelude.Maybe RequestSetOption,
           b ~ Prelude.Maybe RequestSetOption, Prelude.Functor f) =>
          Lens.Labels.HasLens "maybe'setOption" f Request Request a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _Request'setOption
-              (\ x__ y__ -> x__{_Request'setOption = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Request'value
+                 (\ x__ y__ -> x__{_Request'value = y__}))
+              (Lens.Family2.Unchecked.lens
+                 (\ x__ ->
+                    case x__ of
+                        Prelude.Just (Request'SetOption x__val) -> Prelude.Just x__val
+                        _otherwise -> Prelude.Nothing)
+                 (\ _ y__ -> Prelude.fmap Request'SetOption y__))
 
-instance (a ~ RequestDeliverTx, b ~ RequestDeliverTx,
+instance (a ~ RequestSetOption, b ~ RequestSetOption,
           Prelude.Functor f) =>
-         Lens.Labels.HasLens "deliverTx" f Request Request a b
+         Lens.Labels.HasLens "setOption" f Request Request a b
          where
         lensOf _
-          = (Prelude..) maybe'deliverTx
-              (Data.ProtoLens.maybeLens Data.Default.Class.def)
-
-instance (a ~ Prelude.Maybe RequestDeliverTx,
-          b ~ Prelude.Maybe RequestDeliverTx, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'deliverTx" f Request Request a b
-         where
-        lensOf _
-          = Lens.Family2.Unchecked.lens _Request'deliverTx
-              (\ x__ y__ -> x__{_Request'deliverTx = y__})
-
-instance (a ~ RequestCheckTx, b ~ RequestCheckTx,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "checkTx" f Request Request a b
-         where
-        lensOf _
-          = (Prelude..) maybe'checkTx
-              (Data.ProtoLens.maybeLens Data.Default.Class.def)
-
-instance (a ~ Prelude.Maybe RequestCheckTx,
-          b ~ Prelude.Maybe RequestCheckTx, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'checkTx" f Request Request a b
-         where
-        lensOf _
-          = Lens.Family2.Unchecked.lens _Request'checkTx
-              (\ x__ y__ -> x__{_Request'checkTx = y__})
-
-instance (a ~ RequestCommit, b ~ RequestCommit,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "commit" f Request Request a b
-         where
-        lensOf _
-          = (Prelude..) maybe'commit
-              (Data.ProtoLens.maybeLens Data.Default.Class.def)
-
-instance (a ~ Prelude.Maybe RequestCommit,
-          b ~ Prelude.Maybe RequestCommit, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'commit" f Request Request a b
-         where
-        lensOf _
-          = Lens.Family2.Unchecked.lens _Request'commit
-              (\ x__ y__ -> x__{_Request'commit = y__})
-
-instance (a ~ RequestQuery, b ~ RequestQuery, Prelude.Functor f) =>
-         Lens.Labels.HasLens "query" f Request Request a b
-         where
-        lensOf _
-          = (Prelude..) maybe'query
-              (Data.ProtoLens.maybeLens Data.Default.Class.def)
-
-instance (a ~ Prelude.Maybe RequestQuery,
-          b ~ Prelude.Maybe RequestQuery, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'query" f Request Request a b
-         where
-        lensOf _
-          = Lens.Family2.Unchecked.lens _Request'query
-              (\ x__ y__ -> x__{_Request'query = y__})
-
-instance (a ~ RequestInitChain, b ~ RequestInitChain,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "initChain" f Request Request a b
-         where
-        lensOf _
-          = (Prelude..) maybe'initChain
-              (Data.ProtoLens.maybeLens Data.Default.Class.def)
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Request'value
+                 (\ x__ y__ -> x__{_Request'value = y__}))
+              ((Prelude..)
+                 (Lens.Family2.Unchecked.lens
+                    (\ x__ ->
+                       case x__ of
+                           Prelude.Just (Request'SetOption x__val) -> Prelude.Just x__val
+                           _otherwise -> Prelude.Nothing)
+                    (\ _ y__ -> Prelude.fmap Request'SetOption y__))
+                 (Data.ProtoLens.maybeLens Data.Default.Class.def))
 
 instance (a ~ Prelude.Maybe RequestInitChain,
           b ~ Prelude.Maybe RequestInitChain, Prelude.Functor f) =>
          Lens.Labels.HasLens "maybe'initChain" f Request Request a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _Request'initChain
-              (\ x__ y__ -> x__{_Request'initChain = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Request'value
+                 (\ x__ y__ -> x__{_Request'value = y__}))
+              (Lens.Family2.Unchecked.lens
+                 (\ x__ ->
+                    case x__ of
+                        Prelude.Just (Request'InitChain x__val) -> Prelude.Just x__val
+                        _otherwise -> Prelude.Nothing)
+                 (\ _ y__ -> Prelude.fmap Request'InitChain y__))
 
-instance (a ~ RequestBeginBlock, b ~ RequestBeginBlock,
+instance (a ~ RequestInitChain, b ~ RequestInitChain,
           Prelude.Functor f) =>
-         Lens.Labels.HasLens "beginBlock" f Request Request a b
+         Lens.Labels.HasLens "initChain" f Request Request a b
          where
         lensOf _
-          = (Prelude..) maybe'beginBlock
-              (Data.ProtoLens.maybeLens Data.Default.Class.def)
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Request'value
+                 (\ x__ y__ -> x__{_Request'value = y__}))
+              ((Prelude..)
+                 (Lens.Family2.Unchecked.lens
+                    (\ x__ ->
+                       case x__ of
+                           Prelude.Just (Request'InitChain x__val) -> Prelude.Just x__val
+                           _otherwise -> Prelude.Nothing)
+                    (\ _ y__ -> Prelude.fmap Request'InitChain y__))
+                 (Data.ProtoLens.maybeLens Data.Default.Class.def))
+
+instance (a ~ Prelude.Maybe RequestQuery,
+          b ~ Prelude.Maybe RequestQuery, Prelude.Functor f) =>
+         Lens.Labels.HasLens "maybe'query" f Request Request a b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Request'value
+                 (\ x__ y__ -> x__{_Request'value = y__}))
+              (Lens.Family2.Unchecked.lens
+                 (\ x__ ->
+                    case x__ of
+                        Prelude.Just (Request'Query x__val) -> Prelude.Just x__val
+                        _otherwise -> Prelude.Nothing)
+                 (\ _ y__ -> Prelude.fmap Request'Query y__))
+
+instance (a ~ RequestQuery, b ~ RequestQuery, Prelude.Functor f) =>
+         Lens.Labels.HasLens "query" f Request Request a b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Request'value
+                 (\ x__ y__ -> x__{_Request'value = y__}))
+              ((Prelude..)
+                 (Lens.Family2.Unchecked.lens
+                    (\ x__ ->
+                       case x__ of
+                           Prelude.Just (Request'Query x__val) -> Prelude.Just x__val
+                           _otherwise -> Prelude.Nothing)
+                    (\ _ y__ -> Prelude.fmap Request'Query y__))
+                 (Data.ProtoLens.maybeLens Data.Default.Class.def))
 
 instance (a ~ Prelude.Maybe RequestBeginBlock,
           b ~ Prelude.Maybe RequestBeginBlock, Prelude.Functor f) =>
          Lens.Labels.HasLens "maybe'beginBlock" f Request Request a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _Request'beginBlock
-              (\ x__ y__ -> x__{_Request'beginBlock = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Request'value
+                 (\ x__ y__ -> x__{_Request'value = y__}))
+              (Lens.Family2.Unchecked.lens
+                 (\ x__ ->
+                    case x__ of
+                        Prelude.Just (Request'BeginBlock x__val) -> Prelude.Just x__val
+                        _otherwise -> Prelude.Nothing)
+                 (\ _ y__ -> Prelude.fmap Request'BeginBlock y__))
 
-instance (a ~ RequestEndBlock, b ~ RequestEndBlock,
+instance (a ~ RequestBeginBlock, b ~ RequestBeginBlock,
           Prelude.Functor f) =>
-         Lens.Labels.HasLens "endBlock" f Request Request a b
+         Lens.Labels.HasLens "beginBlock" f Request Request a b
          where
         lensOf _
-          = (Prelude..) maybe'endBlock
-              (Data.ProtoLens.maybeLens Data.Default.Class.def)
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Request'value
+                 (\ x__ y__ -> x__{_Request'value = y__}))
+              ((Prelude..)
+                 (Lens.Family2.Unchecked.lens
+                    (\ x__ ->
+                       case x__ of
+                           Prelude.Just (Request'BeginBlock x__val) -> Prelude.Just x__val
+                           _otherwise -> Prelude.Nothing)
+                    (\ _ y__ -> Prelude.fmap Request'BeginBlock y__))
+                 (Data.ProtoLens.maybeLens Data.Default.Class.def))
+
+instance (a ~ Prelude.Maybe RequestCheckTx,
+          b ~ Prelude.Maybe RequestCheckTx, Prelude.Functor f) =>
+         Lens.Labels.HasLens "maybe'checkTx" f Request Request a b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Request'value
+                 (\ x__ y__ -> x__{_Request'value = y__}))
+              (Lens.Family2.Unchecked.lens
+                 (\ x__ ->
+                    case x__ of
+                        Prelude.Just (Request'CheckTx x__val) -> Prelude.Just x__val
+                        _otherwise -> Prelude.Nothing)
+                 (\ _ y__ -> Prelude.fmap Request'CheckTx y__))
+
+instance (a ~ RequestCheckTx, b ~ RequestCheckTx,
+          Prelude.Functor f) =>
+         Lens.Labels.HasLens "checkTx" f Request Request a b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Request'value
+                 (\ x__ y__ -> x__{_Request'value = y__}))
+              ((Prelude..)
+                 (Lens.Family2.Unchecked.lens
+                    (\ x__ ->
+                       case x__ of
+                           Prelude.Just (Request'CheckTx x__val) -> Prelude.Just x__val
+                           _otherwise -> Prelude.Nothing)
+                    (\ _ y__ -> Prelude.fmap Request'CheckTx y__))
+                 (Data.ProtoLens.maybeLens Data.Default.Class.def))
+
+instance (a ~ Prelude.Maybe RequestDeliverTx,
+          b ~ Prelude.Maybe RequestDeliverTx, Prelude.Functor f) =>
+         Lens.Labels.HasLens "maybe'deliverTx" f Request Request a b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Request'value
+                 (\ x__ y__ -> x__{_Request'value = y__}))
+              (Lens.Family2.Unchecked.lens
+                 (\ x__ ->
+                    case x__ of
+                        Prelude.Just (Request'DeliverTx x__val) -> Prelude.Just x__val
+                        _otherwise -> Prelude.Nothing)
+                 (\ _ y__ -> Prelude.fmap Request'DeliverTx y__))
+
+instance (a ~ RequestDeliverTx, b ~ RequestDeliverTx,
+          Prelude.Functor f) =>
+         Lens.Labels.HasLens "deliverTx" f Request Request a b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Request'value
+                 (\ x__ y__ -> x__{_Request'value = y__}))
+              ((Prelude..)
+                 (Lens.Family2.Unchecked.lens
+                    (\ x__ ->
+                       case x__ of
+                           Prelude.Just (Request'DeliverTx x__val) -> Prelude.Just x__val
+                           _otherwise -> Prelude.Nothing)
+                    (\ _ y__ -> Prelude.fmap Request'DeliverTx y__))
+                 (Data.ProtoLens.maybeLens Data.Default.Class.def))
 
 instance (a ~ Prelude.Maybe RequestEndBlock,
           b ~ Prelude.Maybe RequestEndBlock, Prelude.Functor f) =>
          Lens.Labels.HasLens "maybe'endBlock" f Request Request a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _Request'endBlock
-              (\ x__ y__ -> x__{_Request'endBlock = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Request'value
+                 (\ x__ y__ -> x__{_Request'value = y__}))
+              (Lens.Family2.Unchecked.lens
+                 (\ x__ ->
+                    case x__ of
+                        Prelude.Just (Request'EndBlock x__val) -> Prelude.Just x__val
+                        _otherwise -> Prelude.Nothing)
+                 (\ _ y__ -> Prelude.fmap Request'EndBlock y__))
+
+instance (a ~ RequestEndBlock, b ~ RequestEndBlock,
+          Prelude.Functor f) =>
+         Lens.Labels.HasLens "endBlock" f Request Request a b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Request'value
+                 (\ x__ y__ -> x__{_Request'value = y__}))
+              ((Prelude..)
+                 (Lens.Family2.Unchecked.lens
+                    (\ x__ ->
+                       case x__ of
+                           Prelude.Just (Request'EndBlock x__val) -> Prelude.Just x__val
+                           _otherwise -> Prelude.Nothing)
+                    (\ _ y__ -> Prelude.fmap Request'EndBlock y__))
+                 (Data.ProtoLens.maybeLens Data.Default.Class.def))
+
+instance (a ~ Prelude.Maybe RequestCommit,
+          b ~ Prelude.Maybe RequestCommit, Prelude.Functor f) =>
+         Lens.Labels.HasLens "maybe'commit" f Request Request a b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Request'value
+                 (\ x__ y__ -> x__{_Request'value = y__}))
+              (Lens.Family2.Unchecked.lens
+                 (\ x__ ->
+                    case x__ of
+                        Prelude.Just (Request'Commit x__val) -> Prelude.Just x__val
+                        _otherwise -> Prelude.Nothing)
+                 (\ _ y__ -> Prelude.fmap Request'Commit y__))
+
+instance (a ~ RequestCommit, b ~ RequestCommit,
+          Prelude.Functor f) =>
+         Lens.Labels.HasLens "commit" f Request Request a b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Request'value
+                 (\ x__ y__ -> x__{_Request'value = y__}))
+              ((Prelude..)
+                 (Lens.Family2.Unchecked.lens
+                    (\ x__ ->
+                       case x__ of
+                           Prelude.Just (Request'Commit x__val) -> Prelude.Just x__val
+                           _otherwise -> Prelude.Nothing)
+                    (\ _ y__ -> Prelude.fmap Request'Commit y__))
+                 (Data.ProtoLens.maybeLens Data.Default.Class.def))
 
 instance Data.Default.Class.Default Request where
-        def
-          = Request{_Request'echo = Prelude.Nothing,
-                    _Request'flush = Prelude.Nothing, _Request'info = Prelude.Nothing,
-                    _Request'setOption = Prelude.Nothing,
-                    _Request'deliverTx = Prelude.Nothing,
-                    _Request'checkTx = Prelude.Nothing,
-                    _Request'commit = Prelude.Nothing,
-                    _Request'query = Prelude.Nothing,
-                    _Request'initChain = Prelude.Nothing,
-                    _Request'beginBlock = Prelude.Nothing,
-                    _Request'endBlock = Prelude.Nothing}
+        def = Request{_Request'value = Prelude.Nothing}
 
 instance Data.ProtoLens.Message Request where
         descriptor
@@ -782,23 +1160,11 @@ instance Data.ProtoLens.Message Request where
                          Data.ProtoLens.FieldTypeDescriptor RequestSetOption)
                       (Data.ProtoLens.OptionalField maybe'setOption)
                       :: Data.ProtoLens.FieldDescriptor Request
-                deliverTx__field_descriptor
-                  = Data.ProtoLens.FieldDescriptor "deliver_tx"
+                initChain__field_descriptor
+                  = Data.ProtoLens.FieldDescriptor "init_chain"
                       (Data.ProtoLens.MessageField ::
-                         Data.ProtoLens.FieldTypeDescriptor RequestDeliverTx)
-                      (Data.ProtoLens.OptionalField maybe'deliverTx)
-                      :: Data.ProtoLens.FieldDescriptor Request
-                checkTx__field_descriptor
-                  = Data.ProtoLens.FieldDescriptor "check_tx"
-                      (Data.ProtoLens.MessageField ::
-                         Data.ProtoLens.FieldTypeDescriptor RequestCheckTx)
-                      (Data.ProtoLens.OptionalField maybe'checkTx)
-                      :: Data.ProtoLens.FieldDescriptor Request
-                commit__field_descriptor
-                  = Data.ProtoLens.FieldDescriptor "commit"
-                      (Data.ProtoLens.MessageField ::
-                         Data.ProtoLens.FieldTypeDescriptor RequestCommit)
-                      (Data.ProtoLens.OptionalField maybe'commit)
+                         Data.ProtoLens.FieldTypeDescriptor RequestInitChain)
+                      (Data.ProtoLens.OptionalField maybe'initChain)
                       :: Data.ProtoLens.FieldDescriptor Request
                 query__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "query"
@@ -806,17 +1172,23 @@ instance Data.ProtoLens.Message Request where
                          Data.ProtoLens.FieldTypeDescriptor RequestQuery)
                       (Data.ProtoLens.OptionalField maybe'query)
                       :: Data.ProtoLens.FieldDescriptor Request
-                initChain__field_descriptor
-                  = Data.ProtoLens.FieldDescriptor "init_chain"
-                      (Data.ProtoLens.MessageField ::
-                         Data.ProtoLens.FieldTypeDescriptor RequestInitChain)
-                      (Data.ProtoLens.OptionalField maybe'initChain)
-                      :: Data.ProtoLens.FieldDescriptor Request
                 beginBlock__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "begin_block"
                       (Data.ProtoLens.MessageField ::
                          Data.ProtoLens.FieldTypeDescriptor RequestBeginBlock)
                       (Data.ProtoLens.OptionalField maybe'beginBlock)
+                      :: Data.ProtoLens.FieldDescriptor Request
+                checkTx__field_descriptor
+                  = Data.ProtoLens.FieldDescriptor "check_tx"
+                      (Data.ProtoLens.MessageField ::
+                         Data.ProtoLens.FieldTypeDescriptor RequestCheckTx)
+                      (Data.ProtoLens.OptionalField maybe'checkTx)
+                      :: Data.ProtoLens.FieldDescriptor Request
+                deliverTx__field_descriptor
+                  = Data.ProtoLens.FieldDescriptor "deliver_tx"
+                      (Data.ProtoLens.MessageField ::
+                         Data.ProtoLens.FieldTypeDescriptor RequestDeliverTx)
+                      (Data.ProtoLens.OptionalField maybe'deliverTx)
                       :: Data.ProtoLens.FieldDescriptor Request
                 endBlock__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "end_block"
@@ -824,37 +1196,45 @@ instance Data.ProtoLens.Message Request where
                          Data.ProtoLens.FieldTypeDescriptor RequestEndBlock)
                       (Data.ProtoLens.OptionalField maybe'endBlock)
                       :: Data.ProtoLens.FieldDescriptor Request
+                commit__field_descriptor
+                  = Data.ProtoLens.FieldDescriptor "commit"
+                      (Data.ProtoLens.MessageField ::
+                         Data.ProtoLens.FieldTypeDescriptor RequestCommit)
+                      (Data.ProtoLens.OptionalField maybe'commit)
+                      :: Data.ProtoLens.FieldDescriptor Request
               in
-              Data.ProtoLens.MessageDescriptor
+              Data.ProtoLens.MessageDescriptor (Data.Text.pack "types.Request")
                 (Data.Map.fromList
-                   [(Data.ProtoLens.Tag 1, echo__field_descriptor),
-                    (Data.ProtoLens.Tag 2, flush__field_descriptor),
-                    (Data.ProtoLens.Tag 3, info__field_descriptor),
-                    (Data.ProtoLens.Tag 4, setOption__field_descriptor),
-                    (Data.ProtoLens.Tag 5, deliverTx__field_descriptor),
-                    (Data.ProtoLens.Tag 6, checkTx__field_descriptor),
-                    (Data.ProtoLens.Tag 7, commit__field_descriptor),
-                    (Data.ProtoLens.Tag 8, query__field_descriptor),
-                    (Data.ProtoLens.Tag 9, initChain__field_descriptor),
-                    (Data.ProtoLens.Tag 10, beginBlock__field_descriptor),
-                    (Data.ProtoLens.Tag 11, endBlock__field_descriptor)])
+                   [(Data.ProtoLens.Tag 2, echo__field_descriptor),
+                    (Data.ProtoLens.Tag 3, flush__field_descriptor),
+                    (Data.ProtoLens.Tag 4, info__field_descriptor),
+                    (Data.ProtoLens.Tag 5, setOption__field_descriptor),
+                    (Data.ProtoLens.Tag 6, initChain__field_descriptor),
+                    (Data.ProtoLens.Tag 7, query__field_descriptor),
+                    (Data.ProtoLens.Tag 8, beginBlock__field_descriptor),
+                    (Data.ProtoLens.Tag 9, checkTx__field_descriptor),
+                    (Data.ProtoLens.Tag 19, deliverTx__field_descriptor),
+                    (Data.ProtoLens.Tag 11, endBlock__field_descriptor),
+                    (Data.ProtoLens.Tag 12, commit__field_descriptor)])
                 (Data.Map.fromList
                    [("echo", echo__field_descriptor),
                     ("flush", flush__field_descriptor),
                     ("info", info__field_descriptor),
                     ("set_option", setOption__field_descriptor),
-                    ("deliver_tx", deliverTx__field_descriptor),
-                    ("check_tx", checkTx__field_descriptor),
-                    ("commit", commit__field_descriptor),
-                    ("query", query__field_descriptor),
                     ("init_chain", initChain__field_descriptor),
+                    ("query", query__field_descriptor),
                     ("begin_block", beginBlock__field_descriptor),
-                    ("end_block", endBlock__field_descriptor)])
+                    ("check_tx", checkTx__field_descriptor),
+                    ("deliver_tx", deliverTx__field_descriptor),
+                    ("end_block", endBlock__field_descriptor),
+                    ("commit", commit__field_descriptor)])
 
 data RequestBeginBlock = RequestBeginBlock{_RequestBeginBlock'hash
                                            :: !Data.ByteString.ByteString,
-                                           _RequestBeginBlock'header :: !(Prelude.Maybe Header)}
-                       deriving (Prelude.Show, Prelude.Eq)
+                                           _RequestBeginBlock'header :: !(Prelude.Maybe Header),
+                                           _RequestBeginBlock'absentValidators :: ![Data.Int.Int32],
+                                           _RequestBeginBlock'byzantineValidators :: ![Evidence]}
+                       deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
 instance (a ~ Data.ByteString.ByteString,
           b ~ Data.ByteString.ByteString, Prelude.Functor f) =>
@@ -862,8 +1242,10 @@ instance (a ~ Data.ByteString.ByteString,
            b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _RequestBeginBlock'hash
-              (\ x__ y__ -> x__{_RequestBeginBlock'hash = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _RequestBeginBlock'hash
+                 (\ x__ y__ -> x__{_RequestBeginBlock'hash = y__}))
+              Prelude.id
 
 instance (a ~ Header, b ~ Header, Prelude.Functor f) =>
          Lens.Labels.HasLens "header" f RequestBeginBlock RequestBeginBlock
@@ -871,7 +1253,9 @@ instance (a ~ Header, b ~ Header, Prelude.Functor f) =>
            b
          where
         lensOf _
-          = (Prelude..) maybe'header
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _RequestBeginBlock'header
+                 (\ x__ y__ -> x__{_RequestBeginBlock'header = y__}))
               (Data.ProtoLens.maybeLens Data.Default.Class.def)
 
 instance (a ~ Prelude.Maybe Header, b ~ Prelude.Maybe Header,
@@ -882,14 +1266,43 @@ instance (a ~ Prelude.Maybe Header, b ~ Prelude.Maybe Header,
            b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _RequestBeginBlock'header
-              (\ x__ y__ -> x__{_RequestBeginBlock'header = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _RequestBeginBlock'header
+                 (\ x__ y__ -> x__{_RequestBeginBlock'header = y__}))
+              Prelude.id
+
+instance (a ~ [Data.Int.Int32], b ~ [Data.Int.Int32],
+          Prelude.Functor f) =>
+         Lens.Labels.HasLens "absentValidators" f RequestBeginBlock
+           RequestBeginBlock
+           a
+           b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _RequestBeginBlock'absentValidators
+                 (\ x__ y__ -> x__{_RequestBeginBlock'absentValidators = y__}))
+              Prelude.id
+
+instance (a ~ [Evidence], b ~ [Evidence], Prelude.Functor f) =>
+         Lens.Labels.HasLens "byzantineValidators" f RequestBeginBlock
+           RequestBeginBlock
+           a
+           b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _RequestBeginBlock'byzantineValidators
+                 (\ x__ y__ -> x__{_RequestBeginBlock'byzantineValidators = y__}))
+              Prelude.id
 
 instance Data.Default.Class.Default RequestBeginBlock where
         def
           = RequestBeginBlock{_RequestBeginBlock'hash =
                                 Data.ProtoLens.fieldDefault,
-                              _RequestBeginBlock'header = Prelude.Nothing}
+                              _RequestBeginBlock'header = Prelude.Nothing,
+                              _RequestBeginBlock'absentValidators = [],
+                              _RequestBeginBlock'byzantineValidators = []}
 
 instance Data.ProtoLens.Message RequestBeginBlock where
         descriptor
@@ -905,26 +1318,47 @@ instance Data.ProtoLens.Message RequestBeginBlock where
                          Data.ProtoLens.FieldTypeDescriptor Header)
                       (Data.ProtoLens.OptionalField maybe'header)
                       :: Data.ProtoLens.FieldDescriptor RequestBeginBlock
+                absentValidators__field_descriptor
+                  = Data.ProtoLens.FieldDescriptor "absent_validators"
+                      (Data.ProtoLens.Int32Field ::
+                         Data.ProtoLens.FieldTypeDescriptor Data.Int.Int32)
+                      (Data.ProtoLens.RepeatedField Data.ProtoLens.Packed
+                         absentValidators)
+                      :: Data.ProtoLens.FieldDescriptor RequestBeginBlock
+                byzantineValidators__field_descriptor
+                  = Data.ProtoLens.FieldDescriptor "byzantine_validators"
+                      (Data.ProtoLens.MessageField ::
+                         Data.ProtoLens.FieldTypeDescriptor Evidence)
+                      (Data.ProtoLens.RepeatedField Data.ProtoLens.Unpacked
+                         byzantineValidators)
+                      :: Data.ProtoLens.FieldDescriptor RequestBeginBlock
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "types.RequestBeginBlock")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 1, hash__field_descriptor),
-                    (Data.ProtoLens.Tag 2, header__field_descriptor)])
+                    (Data.ProtoLens.Tag 2, header__field_descriptor),
+                    (Data.ProtoLens.Tag 3, absentValidators__field_descriptor),
+                    (Data.ProtoLens.Tag 4, byzantineValidators__field_descriptor)])
                 (Data.Map.fromList
                    [("hash", hash__field_descriptor),
-                    ("header", header__field_descriptor)])
+                    ("header", header__field_descriptor),
+                    ("absent_validators", absentValidators__field_descriptor),
+                    ("byzantine_validators", byzantineValidators__field_descriptor)])
 
 data RequestCheckTx = RequestCheckTx{_RequestCheckTx'tx ::
                                      !Data.ByteString.ByteString}
-                    deriving (Prelude.Show, Prelude.Eq)
+                    deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
 instance (a ~ Data.ByteString.ByteString,
           b ~ Data.ByteString.ByteString, Prelude.Functor f) =>
          Lens.Labels.HasLens "tx" f RequestCheckTx RequestCheckTx a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _RequestCheckTx'tx
-              (\ x__ y__ -> x__{_RequestCheckTx'tx = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _RequestCheckTx'tx
+                 (\ x__ y__ -> x__{_RequestCheckTx'tx = y__}))
+              Prelude.id
 
 instance Data.Default.Class.Default RequestCheckTx where
         def
@@ -940,11 +1374,12 @@ instance Data.ProtoLens.Message RequestCheckTx where
                       :: Data.ProtoLens.FieldDescriptor RequestCheckTx
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "types.RequestCheckTx")
                 (Data.Map.fromList [(Data.ProtoLens.Tag 1, tx__field_descriptor)])
                 (Data.Map.fromList [("tx", tx__field_descriptor)])
 
 data RequestCommit = RequestCommit{}
-                   deriving (Prelude.Show, Prelude.Eq)
+                   deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
 instance Data.Default.Class.Default RequestCommit where
         def = RequestCommit{}
@@ -952,20 +1387,24 @@ instance Data.Default.Class.Default RequestCommit where
 instance Data.ProtoLens.Message RequestCommit where
         descriptor
           = let in
-              Data.ProtoLens.MessageDescriptor (Data.Map.fromList [])
+              Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "types.RequestCommit")
+                (Data.Map.fromList [])
                 (Data.Map.fromList [])
 
 data RequestDeliverTx = RequestDeliverTx{_RequestDeliverTx'tx ::
                                          !Data.ByteString.ByteString}
-                      deriving (Prelude.Show, Prelude.Eq)
+                      deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
 instance (a ~ Data.ByteString.ByteString,
           b ~ Data.ByteString.ByteString, Prelude.Functor f) =>
          Lens.Labels.HasLens "tx" f RequestDeliverTx RequestDeliverTx a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _RequestDeliverTx'tx
-              (\ x__ y__ -> x__{_RequestDeliverTx'tx = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _RequestDeliverTx'tx
+                 (\ x__ y__ -> x__{_RequestDeliverTx'tx = y__}))
+              Prelude.id
 
 instance Data.Default.Class.Default RequestDeliverTx where
         def
@@ -982,20 +1421,23 @@ instance Data.ProtoLens.Message RequestDeliverTx where
                       :: Data.ProtoLens.FieldDescriptor RequestDeliverTx
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "types.RequestDeliverTx")
                 (Data.Map.fromList [(Data.ProtoLens.Tag 1, tx__field_descriptor)])
                 (Data.Map.fromList [("tx", tx__field_descriptor)])
 
 data RequestEcho = RequestEcho{_RequestEcho'message ::
                                !Data.Text.Text}
-                 deriving (Prelude.Show, Prelude.Eq)
+                 deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
 instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
           Prelude.Functor f) =>
          Lens.Labels.HasLens "message" f RequestEcho RequestEcho a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _RequestEcho'message
-              (\ x__ y__ -> x__{_RequestEcho'message = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _RequestEcho'message
+                 (\ x__ y__ -> x__{_RequestEcho'message = y__}))
+              Prelude.id
 
 instance Data.Default.Class.Default RequestEcho where
         def
@@ -1011,21 +1453,24 @@ instance Data.ProtoLens.Message RequestEcho where
                       :: Data.ProtoLens.FieldDescriptor RequestEcho
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "types.RequestEcho")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 1, message__field_descriptor)])
                 (Data.Map.fromList [("message", message__field_descriptor)])
 
 data RequestEndBlock = RequestEndBlock{_RequestEndBlock'height ::
-                                       !Data.Word.Word64}
-                     deriving (Prelude.Show, Prelude.Eq)
+                                       !Data.Int.Int64}
+                     deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
-instance (a ~ Data.Word.Word64, b ~ Data.Word.Word64,
+instance (a ~ Data.Int.Int64, b ~ Data.Int.Int64,
           Prelude.Functor f) =>
          Lens.Labels.HasLens "height" f RequestEndBlock RequestEndBlock a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _RequestEndBlock'height
-              (\ x__ y__ -> x__{_RequestEndBlock'height = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _RequestEndBlock'height
+                 (\ x__ y__ -> x__{_RequestEndBlock'height = y__}))
+              Prelude.id
 
 instance Data.Default.Class.Default RequestEndBlock where
         def
@@ -1036,18 +1481,19 @@ instance Data.ProtoLens.Message RequestEndBlock where
         descriptor
           = let height__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "height"
-                      (Data.ProtoLens.UInt64Field ::
-                         Data.ProtoLens.FieldTypeDescriptor Data.Word.Word64)
+                      (Data.ProtoLens.Int64Field ::
+                         Data.ProtoLens.FieldTypeDescriptor Data.Int.Int64)
                       (Data.ProtoLens.PlainField Data.ProtoLens.Optional height)
                       :: Data.ProtoLens.FieldDescriptor RequestEndBlock
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "types.RequestEndBlock")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 1, height__field_descriptor)])
                 (Data.Map.fromList [("height", height__field_descriptor)])
 
 data RequestFlush = RequestFlush{}
-                  deriving (Prelude.Show, Prelude.Eq)
+                  deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
 instance Data.Default.Class.Default RequestFlush where
         def = RequestFlush{}
@@ -1055,24 +1501,47 @@ instance Data.Default.Class.Default RequestFlush where
 instance Data.ProtoLens.Message RequestFlush where
         descriptor
           = let in
-              Data.ProtoLens.MessageDescriptor (Data.Map.fromList [])
+              Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "types.RequestFlush")
+                (Data.Map.fromList [])
                 (Data.Map.fromList [])
 
-data RequestInfo = RequestInfo{}
-                 deriving (Prelude.Show, Prelude.Eq)
+data RequestInfo = RequestInfo{_RequestInfo'version ::
+                               !Data.Text.Text}
+                 deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
+
+instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
+          Prelude.Functor f) =>
+         Lens.Labels.HasLens "version" f RequestInfo RequestInfo a b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _RequestInfo'version
+                 (\ x__ y__ -> x__{_RequestInfo'version = y__}))
+              Prelude.id
 
 instance Data.Default.Class.Default RequestInfo where
-        def = RequestInfo{}
+        def
+          = RequestInfo{_RequestInfo'version = Data.ProtoLens.fieldDefault}
 
 instance Data.ProtoLens.Message RequestInfo where
         descriptor
-          = let in
-              Data.ProtoLens.MessageDescriptor (Data.Map.fromList [])
-                (Data.Map.fromList [])
+          = let version__field_descriptor
+                  = Data.ProtoLens.FieldDescriptor "version"
+                      (Data.ProtoLens.StringField ::
+                         Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
+                      (Data.ProtoLens.PlainField Data.ProtoLens.Optional version)
+                      :: Data.ProtoLens.FieldDescriptor RequestInfo
+              in
+              Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "types.RequestInfo")
+                (Data.Map.fromList
+                   [(Data.ProtoLens.Tag 1, version__field_descriptor)])
+                (Data.Map.fromList [("version", version__field_descriptor)])
 
 data RequestInitChain = RequestInitChain{_RequestInitChain'validators
                                          :: ![Validator]}
-                      deriving (Prelude.Show, Prelude.Eq)
+                      deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
 instance (a ~ [Validator], b ~ [Validator], Prelude.Functor f) =>
          Lens.Labels.HasLens "validators" f RequestInitChain
@@ -1081,8 +1550,10 @@ instance (a ~ [Validator], b ~ [Validator], Prelude.Functor f) =>
            b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _RequestInitChain'validators
-              (\ x__ y__ -> x__{_RequestInitChain'validators = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _RequestInitChain'validators
+                 (\ x__ y__ -> x__{_RequestInitChain'validators = y__}))
+              Prelude.id
 
 instance Data.Default.Class.Default RequestInitChain where
         def = RequestInitChain{_RequestInitChain'validators = []}
@@ -1097,6 +1568,7 @@ instance Data.ProtoLens.Message RequestInitChain where
                       :: Data.ProtoLens.FieldDescriptor RequestInitChain
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "types.RequestInitChain")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 1, validators__field_descriptor)])
                 (Data.Map.fromList [("validators", validators__field_descriptor)])
@@ -1104,40 +1576,48 @@ instance Data.ProtoLens.Message RequestInitChain where
 data RequestQuery = RequestQuery{_RequestQuery'data' ::
                                  !Data.ByteString.ByteString,
                                  _RequestQuery'path :: !Data.Text.Text,
-                                 _RequestQuery'height :: !Data.Word.Word64,
+                                 _RequestQuery'height :: !Data.Int.Int64,
                                  _RequestQuery'prove :: !Prelude.Bool}
-                  deriving (Prelude.Show, Prelude.Eq)
+                  deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
 instance (a ~ Data.ByteString.ByteString,
           b ~ Data.ByteString.ByteString, Prelude.Functor f) =>
          Lens.Labels.HasLens "data'" f RequestQuery RequestQuery a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _RequestQuery'data'
-              (\ x__ y__ -> x__{_RequestQuery'data' = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _RequestQuery'data'
+                 (\ x__ y__ -> x__{_RequestQuery'data' = y__}))
+              Prelude.id
 
 instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
           Prelude.Functor f) =>
          Lens.Labels.HasLens "path" f RequestQuery RequestQuery a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _RequestQuery'path
-              (\ x__ y__ -> x__{_RequestQuery'path = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _RequestQuery'path
+                 (\ x__ y__ -> x__{_RequestQuery'path = y__}))
+              Prelude.id
 
-instance (a ~ Data.Word.Word64, b ~ Data.Word.Word64,
+instance (a ~ Data.Int.Int64, b ~ Data.Int.Int64,
           Prelude.Functor f) =>
          Lens.Labels.HasLens "height" f RequestQuery RequestQuery a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _RequestQuery'height
-              (\ x__ y__ -> x__{_RequestQuery'height = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _RequestQuery'height
+                 (\ x__ y__ -> x__{_RequestQuery'height = y__}))
+              Prelude.id
 
 instance (a ~ Prelude.Bool, b ~ Prelude.Bool, Prelude.Functor f) =>
          Lens.Labels.HasLens "prove" f RequestQuery RequestQuery a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _RequestQuery'prove
-              (\ x__ y__ -> x__{_RequestQuery'prove = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _RequestQuery'prove
+                 (\ x__ y__ -> x__{_RequestQuery'prove = y__}))
+              Prelude.id
 
 instance Data.Default.Class.Default RequestQuery where
         def
@@ -1162,8 +1642,8 @@ instance Data.ProtoLens.Message RequestQuery where
                       :: Data.ProtoLens.FieldDescriptor RequestQuery
                 height__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "height"
-                      (Data.ProtoLens.UInt64Field ::
-                         Data.ProtoLens.FieldTypeDescriptor Data.Word.Word64)
+                      (Data.ProtoLens.Int64Field ::
+                         Data.ProtoLens.FieldTypeDescriptor Data.Int.Int64)
                       (Data.ProtoLens.PlainField Data.ProtoLens.Optional height)
                       :: Data.ProtoLens.FieldDescriptor RequestQuery
                 prove__field_descriptor
@@ -1174,6 +1654,7 @@ instance Data.ProtoLens.Message RequestQuery where
                       :: Data.ProtoLens.FieldDescriptor RequestQuery
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "types.RequestQuery")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 1, data'__field_descriptor),
                     (Data.ProtoLens.Tag 2, path__field_descriptor),
@@ -1188,23 +1669,27 @@ instance Data.ProtoLens.Message RequestQuery where
 data RequestSetOption = RequestSetOption{_RequestSetOption'key ::
                                          !Data.Text.Text,
                                          _RequestSetOption'value :: !Data.Text.Text}
-                      deriving (Prelude.Show, Prelude.Eq)
+                      deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
 instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
           Prelude.Functor f) =>
          Lens.Labels.HasLens "key" f RequestSetOption RequestSetOption a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _RequestSetOption'key
-              (\ x__ y__ -> x__{_RequestSetOption'key = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _RequestSetOption'key
+                 (\ x__ y__ -> x__{_RequestSetOption'key = y__}))
+              Prelude.id
 
 instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
           Prelude.Functor f) =>
          Lens.Labels.HasLens "value" f RequestSetOption RequestSetOption a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _RequestSetOption'value
-              (\ x__ y__ -> x__{_RequestSetOption'value = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _RequestSetOption'value
+                 (\ x__ y__ -> x__{_RequestSetOption'value = y__}))
+              Prelude.id
 
 instance Data.Default.Class.Default RequestSetOption where
         def
@@ -1228,6 +1713,7 @@ instance Data.ProtoLens.Message RequestSetOption where
                       :: Data.ProtoLens.FieldDescriptor RequestSetOption
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "types.RequestSetOption")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 1, key__field_descriptor),
                     (Data.ProtoLens.Tag 2, value__field_descriptor)])
@@ -1235,225 +1721,418 @@ instance Data.ProtoLens.Message RequestSetOption where
                    [("key", key__field_descriptor),
                     ("value", value__field_descriptor)])
 
-data Response = Response{_Response'exception ::
-                         !(Prelude.Maybe ResponseException),
-                         _Response'echo :: !(Prelude.Maybe ResponseEcho),
-                         _Response'flush :: !(Prelude.Maybe ResponseFlush),
-                         _Response'info :: !(Prelude.Maybe ResponseInfo),
-                         _Response'setOption :: !(Prelude.Maybe ResponseSetOption),
-                         _Response'deliverTx :: !(Prelude.Maybe ResponseDeliverTx),
-                         _Response'checkTx :: !(Prelude.Maybe ResponseCheckTx),
-                         _Response'commit :: !(Prelude.Maybe ResponseCommit),
-                         _Response'query :: !(Prelude.Maybe ResponseQuery),
-                         _Response'initChain :: !(Prelude.Maybe ResponseInitChain),
-                         _Response'beginBlock :: !(Prelude.Maybe ResponseBeginBlock),
-                         _Response'endBlock :: !(Prelude.Maybe ResponseEndBlock)}
-              deriving (Prelude.Show, Prelude.Eq)
+data Response = Response{_Response'value ::
+                         !(Prelude.Maybe Response'Value)}
+              deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
-instance (a ~ ResponseException, b ~ ResponseException,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "exception" f Response Response a b
+data Response'Value = Response'Exception !ResponseException
+                    | Response'Echo !ResponseEcho
+                    | Response'Flush !ResponseFlush
+                    | Response'Info !ResponseInfo
+                    | Response'SetOption !ResponseSetOption
+                    | Response'InitChain !ResponseInitChain
+                    | Response'Query !ResponseQuery
+                    | Response'BeginBlock !ResponseBeginBlock
+                    | Response'CheckTx !ResponseCheckTx
+                    | Response'DeliverTx !ResponseDeliverTx
+                    | Response'EndBlock !ResponseEndBlock
+                    | Response'Commit !ResponseCommit
+                    deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
+
+instance (a ~ Prelude.Maybe Response'Value,
+          b ~ Prelude.Maybe Response'Value, Prelude.Functor f) =>
+         Lens.Labels.HasLens "maybe'value" f Response Response a b
          where
         lensOf _
-          = (Prelude..) maybe'exception
-              (Data.ProtoLens.maybeLens Data.Default.Class.def)
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Response'value
+                 (\ x__ y__ -> x__{_Response'value = y__}))
+              Prelude.id
 
 instance (a ~ Prelude.Maybe ResponseException,
           b ~ Prelude.Maybe ResponseException, Prelude.Functor f) =>
          Lens.Labels.HasLens "maybe'exception" f Response Response a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _Response'exception
-              (\ x__ y__ -> x__{_Response'exception = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Response'value
+                 (\ x__ y__ -> x__{_Response'value = y__}))
+              (Lens.Family2.Unchecked.lens
+                 (\ x__ ->
+                    case x__ of
+                        Prelude.Just (Response'Exception x__val) -> Prelude.Just x__val
+                        _otherwise -> Prelude.Nothing)
+                 (\ _ y__ -> Prelude.fmap Response'Exception y__))
 
-instance (a ~ ResponseEcho, b ~ ResponseEcho, Prelude.Functor f) =>
-         Lens.Labels.HasLens "echo" f Response Response a b
+instance (a ~ ResponseException, b ~ ResponseException,
+          Prelude.Functor f) =>
+         Lens.Labels.HasLens "exception" f Response Response a b
          where
         lensOf _
-          = (Prelude..) maybe'echo
-              (Data.ProtoLens.maybeLens Data.Default.Class.def)
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Response'value
+                 (\ x__ y__ -> x__{_Response'value = y__}))
+              ((Prelude..)
+                 (Lens.Family2.Unchecked.lens
+                    (\ x__ ->
+                       case x__ of
+                           Prelude.Just (Response'Exception x__val) -> Prelude.Just x__val
+                           _otherwise -> Prelude.Nothing)
+                    (\ _ y__ -> Prelude.fmap Response'Exception y__))
+                 (Data.ProtoLens.maybeLens Data.Default.Class.def))
 
 instance (a ~ Prelude.Maybe ResponseEcho,
           b ~ Prelude.Maybe ResponseEcho, Prelude.Functor f) =>
          Lens.Labels.HasLens "maybe'echo" f Response Response a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _Response'echo
-              (\ x__ y__ -> x__{_Response'echo = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Response'value
+                 (\ x__ y__ -> x__{_Response'value = y__}))
+              (Lens.Family2.Unchecked.lens
+                 (\ x__ ->
+                    case x__ of
+                        Prelude.Just (Response'Echo x__val) -> Prelude.Just x__val
+                        _otherwise -> Prelude.Nothing)
+                 (\ _ y__ -> Prelude.fmap Response'Echo y__))
 
-instance (a ~ ResponseFlush, b ~ ResponseFlush,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "flush" f Response Response a b
+instance (a ~ ResponseEcho, b ~ ResponseEcho, Prelude.Functor f) =>
+         Lens.Labels.HasLens "echo" f Response Response a b
          where
         lensOf _
-          = (Prelude..) maybe'flush
-              (Data.ProtoLens.maybeLens Data.Default.Class.def)
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Response'value
+                 (\ x__ y__ -> x__{_Response'value = y__}))
+              ((Prelude..)
+                 (Lens.Family2.Unchecked.lens
+                    (\ x__ ->
+                       case x__ of
+                           Prelude.Just (Response'Echo x__val) -> Prelude.Just x__val
+                           _otherwise -> Prelude.Nothing)
+                    (\ _ y__ -> Prelude.fmap Response'Echo y__))
+                 (Data.ProtoLens.maybeLens Data.Default.Class.def))
 
 instance (a ~ Prelude.Maybe ResponseFlush,
           b ~ Prelude.Maybe ResponseFlush, Prelude.Functor f) =>
          Lens.Labels.HasLens "maybe'flush" f Response Response a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _Response'flush
-              (\ x__ y__ -> x__{_Response'flush = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Response'value
+                 (\ x__ y__ -> x__{_Response'value = y__}))
+              (Lens.Family2.Unchecked.lens
+                 (\ x__ ->
+                    case x__ of
+                        Prelude.Just (Response'Flush x__val) -> Prelude.Just x__val
+                        _otherwise -> Prelude.Nothing)
+                 (\ _ y__ -> Prelude.fmap Response'Flush y__))
 
-instance (a ~ ResponseInfo, b ~ ResponseInfo, Prelude.Functor f) =>
-         Lens.Labels.HasLens "info" f Response Response a b
+instance (a ~ ResponseFlush, b ~ ResponseFlush,
+          Prelude.Functor f) =>
+         Lens.Labels.HasLens "flush" f Response Response a b
          where
         lensOf _
-          = (Prelude..) maybe'info
-              (Data.ProtoLens.maybeLens Data.Default.Class.def)
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Response'value
+                 (\ x__ y__ -> x__{_Response'value = y__}))
+              ((Prelude..)
+                 (Lens.Family2.Unchecked.lens
+                    (\ x__ ->
+                       case x__ of
+                           Prelude.Just (Response'Flush x__val) -> Prelude.Just x__val
+                           _otherwise -> Prelude.Nothing)
+                    (\ _ y__ -> Prelude.fmap Response'Flush y__))
+                 (Data.ProtoLens.maybeLens Data.Default.Class.def))
 
 instance (a ~ Prelude.Maybe ResponseInfo,
           b ~ Prelude.Maybe ResponseInfo, Prelude.Functor f) =>
          Lens.Labels.HasLens "maybe'info" f Response Response a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _Response'info
-              (\ x__ y__ -> x__{_Response'info = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Response'value
+                 (\ x__ y__ -> x__{_Response'value = y__}))
+              (Lens.Family2.Unchecked.lens
+                 (\ x__ ->
+                    case x__ of
+                        Prelude.Just (Response'Info x__val) -> Prelude.Just x__val
+                        _otherwise -> Prelude.Nothing)
+                 (\ _ y__ -> Prelude.fmap Response'Info y__))
 
-instance (a ~ ResponseSetOption, b ~ ResponseSetOption,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "setOption" f Response Response a b
+instance (a ~ ResponseInfo, b ~ ResponseInfo, Prelude.Functor f) =>
+         Lens.Labels.HasLens "info" f Response Response a b
          where
         lensOf _
-          = (Prelude..) maybe'setOption
-              (Data.ProtoLens.maybeLens Data.Default.Class.def)
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Response'value
+                 (\ x__ y__ -> x__{_Response'value = y__}))
+              ((Prelude..)
+                 (Lens.Family2.Unchecked.lens
+                    (\ x__ ->
+                       case x__ of
+                           Prelude.Just (Response'Info x__val) -> Prelude.Just x__val
+                           _otherwise -> Prelude.Nothing)
+                    (\ _ y__ -> Prelude.fmap Response'Info y__))
+                 (Data.ProtoLens.maybeLens Data.Default.Class.def))
 
 instance (a ~ Prelude.Maybe ResponseSetOption,
           b ~ Prelude.Maybe ResponseSetOption, Prelude.Functor f) =>
          Lens.Labels.HasLens "maybe'setOption" f Response Response a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _Response'setOption
-              (\ x__ y__ -> x__{_Response'setOption = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Response'value
+                 (\ x__ y__ -> x__{_Response'value = y__}))
+              (Lens.Family2.Unchecked.lens
+                 (\ x__ ->
+                    case x__ of
+                        Prelude.Just (Response'SetOption x__val) -> Prelude.Just x__val
+                        _otherwise -> Prelude.Nothing)
+                 (\ _ y__ -> Prelude.fmap Response'SetOption y__))
 
-instance (a ~ ResponseDeliverTx, b ~ ResponseDeliverTx,
+instance (a ~ ResponseSetOption, b ~ ResponseSetOption,
           Prelude.Functor f) =>
-         Lens.Labels.HasLens "deliverTx" f Response Response a b
+         Lens.Labels.HasLens "setOption" f Response Response a b
          where
         lensOf _
-          = (Prelude..) maybe'deliverTx
-              (Data.ProtoLens.maybeLens Data.Default.Class.def)
-
-instance (a ~ Prelude.Maybe ResponseDeliverTx,
-          b ~ Prelude.Maybe ResponseDeliverTx, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'deliverTx" f Response Response a b
-         where
-        lensOf _
-          = Lens.Family2.Unchecked.lens _Response'deliverTx
-              (\ x__ y__ -> x__{_Response'deliverTx = y__})
-
-instance (a ~ ResponseCheckTx, b ~ ResponseCheckTx,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "checkTx" f Response Response a b
-         where
-        lensOf _
-          = (Prelude..) maybe'checkTx
-              (Data.ProtoLens.maybeLens Data.Default.Class.def)
-
-instance (a ~ Prelude.Maybe ResponseCheckTx,
-          b ~ Prelude.Maybe ResponseCheckTx, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'checkTx" f Response Response a b
-         where
-        lensOf _
-          = Lens.Family2.Unchecked.lens _Response'checkTx
-              (\ x__ y__ -> x__{_Response'checkTx = y__})
-
-instance (a ~ ResponseCommit, b ~ ResponseCommit,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "commit" f Response Response a b
-         where
-        lensOf _
-          = (Prelude..) maybe'commit
-              (Data.ProtoLens.maybeLens Data.Default.Class.def)
-
-instance (a ~ Prelude.Maybe ResponseCommit,
-          b ~ Prelude.Maybe ResponseCommit, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'commit" f Response Response a b
-         where
-        lensOf _
-          = Lens.Family2.Unchecked.lens _Response'commit
-              (\ x__ y__ -> x__{_Response'commit = y__})
-
-instance (a ~ ResponseQuery, b ~ ResponseQuery,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "query" f Response Response a b
-         where
-        lensOf _
-          = (Prelude..) maybe'query
-              (Data.ProtoLens.maybeLens Data.Default.Class.def)
-
-instance (a ~ Prelude.Maybe ResponseQuery,
-          b ~ Prelude.Maybe ResponseQuery, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'query" f Response Response a b
-         where
-        lensOf _
-          = Lens.Family2.Unchecked.lens _Response'query
-              (\ x__ y__ -> x__{_Response'query = y__})
-
-instance (a ~ ResponseInitChain, b ~ ResponseInitChain,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "initChain" f Response Response a b
-         where
-        lensOf _
-          = (Prelude..) maybe'initChain
-              (Data.ProtoLens.maybeLens Data.Default.Class.def)
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Response'value
+                 (\ x__ y__ -> x__{_Response'value = y__}))
+              ((Prelude..)
+                 (Lens.Family2.Unchecked.lens
+                    (\ x__ ->
+                       case x__ of
+                           Prelude.Just (Response'SetOption x__val) -> Prelude.Just x__val
+                           _otherwise -> Prelude.Nothing)
+                    (\ _ y__ -> Prelude.fmap Response'SetOption y__))
+                 (Data.ProtoLens.maybeLens Data.Default.Class.def))
 
 instance (a ~ Prelude.Maybe ResponseInitChain,
           b ~ Prelude.Maybe ResponseInitChain, Prelude.Functor f) =>
          Lens.Labels.HasLens "maybe'initChain" f Response Response a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _Response'initChain
-              (\ x__ y__ -> x__{_Response'initChain = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Response'value
+                 (\ x__ y__ -> x__{_Response'value = y__}))
+              (Lens.Family2.Unchecked.lens
+                 (\ x__ ->
+                    case x__ of
+                        Prelude.Just (Response'InitChain x__val) -> Prelude.Just x__val
+                        _otherwise -> Prelude.Nothing)
+                 (\ _ y__ -> Prelude.fmap Response'InitChain y__))
 
-instance (a ~ ResponseBeginBlock, b ~ ResponseBeginBlock,
+instance (a ~ ResponseInitChain, b ~ ResponseInitChain,
           Prelude.Functor f) =>
-         Lens.Labels.HasLens "beginBlock" f Response Response a b
+         Lens.Labels.HasLens "initChain" f Response Response a b
          where
         lensOf _
-          = (Prelude..) maybe'beginBlock
-              (Data.ProtoLens.maybeLens Data.Default.Class.def)
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Response'value
+                 (\ x__ y__ -> x__{_Response'value = y__}))
+              ((Prelude..)
+                 (Lens.Family2.Unchecked.lens
+                    (\ x__ ->
+                       case x__ of
+                           Prelude.Just (Response'InitChain x__val) -> Prelude.Just x__val
+                           _otherwise -> Prelude.Nothing)
+                    (\ _ y__ -> Prelude.fmap Response'InitChain y__))
+                 (Data.ProtoLens.maybeLens Data.Default.Class.def))
+
+instance (a ~ Prelude.Maybe ResponseQuery,
+          b ~ Prelude.Maybe ResponseQuery, Prelude.Functor f) =>
+         Lens.Labels.HasLens "maybe'query" f Response Response a b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Response'value
+                 (\ x__ y__ -> x__{_Response'value = y__}))
+              (Lens.Family2.Unchecked.lens
+                 (\ x__ ->
+                    case x__ of
+                        Prelude.Just (Response'Query x__val) -> Prelude.Just x__val
+                        _otherwise -> Prelude.Nothing)
+                 (\ _ y__ -> Prelude.fmap Response'Query y__))
+
+instance (a ~ ResponseQuery, b ~ ResponseQuery,
+          Prelude.Functor f) =>
+         Lens.Labels.HasLens "query" f Response Response a b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Response'value
+                 (\ x__ y__ -> x__{_Response'value = y__}))
+              ((Prelude..)
+                 (Lens.Family2.Unchecked.lens
+                    (\ x__ ->
+                       case x__ of
+                           Prelude.Just (Response'Query x__val) -> Prelude.Just x__val
+                           _otherwise -> Prelude.Nothing)
+                    (\ _ y__ -> Prelude.fmap Response'Query y__))
+                 (Data.ProtoLens.maybeLens Data.Default.Class.def))
 
 instance (a ~ Prelude.Maybe ResponseBeginBlock,
           b ~ Prelude.Maybe ResponseBeginBlock, Prelude.Functor f) =>
          Lens.Labels.HasLens "maybe'beginBlock" f Response Response a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _Response'beginBlock
-              (\ x__ y__ -> x__{_Response'beginBlock = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Response'value
+                 (\ x__ y__ -> x__{_Response'value = y__}))
+              (Lens.Family2.Unchecked.lens
+                 (\ x__ ->
+                    case x__ of
+                        Prelude.Just (Response'BeginBlock x__val) -> Prelude.Just x__val
+                        _otherwise -> Prelude.Nothing)
+                 (\ _ y__ -> Prelude.fmap Response'BeginBlock y__))
 
-instance (a ~ ResponseEndBlock, b ~ ResponseEndBlock,
+instance (a ~ ResponseBeginBlock, b ~ ResponseBeginBlock,
           Prelude.Functor f) =>
-         Lens.Labels.HasLens "endBlock" f Response Response a b
+         Lens.Labels.HasLens "beginBlock" f Response Response a b
          where
         lensOf _
-          = (Prelude..) maybe'endBlock
-              (Data.ProtoLens.maybeLens Data.Default.Class.def)
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Response'value
+                 (\ x__ y__ -> x__{_Response'value = y__}))
+              ((Prelude..)
+                 (Lens.Family2.Unchecked.lens
+                    (\ x__ ->
+                       case x__ of
+                           Prelude.Just (Response'BeginBlock x__val) -> Prelude.Just x__val
+                           _otherwise -> Prelude.Nothing)
+                    (\ _ y__ -> Prelude.fmap Response'BeginBlock y__))
+                 (Data.ProtoLens.maybeLens Data.Default.Class.def))
+
+instance (a ~ Prelude.Maybe ResponseCheckTx,
+          b ~ Prelude.Maybe ResponseCheckTx, Prelude.Functor f) =>
+         Lens.Labels.HasLens "maybe'checkTx" f Response Response a b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Response'value
+                 (\ x__ y__ -> x__{_Response'value = y__}))
+              (Lens.Family2.Unchecked.lens
+                 (\ x__ ->
+                    case x__ of
+                        Prelude.Just (Response'CheckTx x__val) -> Prelude.Just x__val
+                        _otherwise -> Prelude.Nothing)
+                 (\ _ y__ -> Prelude.fmap Response'CheckTx y__))
+
+instance (a ~ ResponseCheckTx, b ~ ResponseCheckTx,
+          Prelude.Functor f) =>
+         Lens.Labels.HasLens "checkTx" f Response Response a b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Response'value
+                 (\ x__ y__ -> x__{_Response'value = y__}))
+              ((Prelude..)
+                 (Lens.Family2.Unchecked.lens
+                    (\ x__ ->
+                       case x__ of
+                           Prelude.Just (Response'CheckTx x__val) -> Prelude.Just x__val
+                           _otherwise -> Prelude.Nothing)
+                    (\ _ y__ -> Prelude.fmap Response'CheckTx y__))
+                 (Data.ProtoLens.maybeLens Data.Default.Class.def))
+
+instance (a ~ Prelude.Maybe ResponseDeliverTx,
+          b ~ Prelude.Maybe ResponseDeliverTx, Prelude.Functor f) =>
+         Lens.Labels.HasLens "maybe'deliverTx" f Response Response a b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Response'value
+                 (\ x__ y__ -> x__{_Response'value = y__}))
+              (Lens.Family2.Unchecked.lens
+                 (\ x__ ->
+                    case x__ of
+                        Prelude.Just (Response'DeliverTx x__val) -> Prelude.Just x__val
+                        _otherwise -> Prelude.Nothing)
+                 (\ _ y__ -> Prelude.fmap Response'DeliverTx y__))
+
+instance (a ~ ResponseDeliverTx, b ~ ResponseDeliverTx,
+          Prelude.Functor f) =>
+         Lens.Labels.HasLens "deliverTx" f Response Response a b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Response'value
+                 (\ x__ y__ -> x__{_Response'value = y__}))
+              ((Prelude..)
+                 (Lens.Family2.Unchecked.lens
+                    (\ x__ ->
+                       case x__ of
+                           Prelude.Just (Response'DeliverTx x__val) -> Prelude.Just x__val
+                           _otherwise -> Prelude.Nothing)
+                    (\ _ y__ -> Prelude.fmap Response'DeliverTx y__))
+                 (Data.ProtoLens.maybeLens Data.Default.Class.def))
 
 instance (a ~ Prelude.Maybe ResponseEndBlock,
           b ~ Prelude.Maybe ResponseEndBlock, Prelude.Functor f) =>
          Lens.Labels.HasLens "maybe'endBlock" f Response Response a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _Response'endBlock
-              (\ x__ y__ -> x__{_Response'endBlock = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Response'value
+                 (\ x__ y__ -> x__{_Response'value = y__}))
+              (Lens.Family2.Unchecked.lens
+                 (\ x__ ->
+                    case x__ of
+                        Prelude.Just (Response'EndBlock x__val) -> Prelude.Just x__val
+                        _otherwise -> Prelude.Nothing)
+                 (\ _ y__ -> Prelude.fmap Response'EndBlock y__))
+
+instance (a ~ ResponseEndBlock, b ~ ResponseEndBlock,
+          Prelude.Functor f) =>
+         Lens.Labels.HasLens "endBlock" f Response Response a b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Response'value
+                 (\ x__ y__ -> x__{_Response'value = y__}))
+              ((Prelude..)
+                 (Lens.Family2.Unchecked.lens
+                    (\ x__ ->
+                       case x__ of
+                           Prelude.Just (Response'EndBlock x__val) -> Prelude.Just x__val
+                           _otherwise -> Prelude.Nothing)
+                    (\ _ y__ -> Prelude.fmap Response'EndBlock y__))
+                 (Data.ProtoLens.maybeLens Data.Default.Class.def))
+
+instance (a ~ Prelude.Maybe ResponseCommit,
+          b ~ Prelude.Maybe ResponseCommit, Prelude.Functor f) =>
+         Lens.Labels.HasLens "maybe'commit" f Response Response a b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Response'value
+                 (\ x__ y__ -> x__{_Response'value = y__}))
+              (Lens.Family2.Unchecked.lens
+                 (\ x__ ->
+                    case x__ of
+                        Prelude.Just (Response'Commit x__val) -> Prelude.Just x__val
+                        _otherwise -> Prelude.Nothing)
+                 (\ _ y__ -> Prelude.fmap Response'Commit y__))
+
+instance (a ~ ResponseCommit, b ~ ResponseCommit,
+          Prelude.Functor f) =>
+         Lens.Labels.HasLens "commit" f Response Response a b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Response'value
+                 (\ x__ y__ -> x__{_Response'value = y__}))
+              ((Prelude..)
+                 (Lens.Family2.Unchecked.lens
+                    (\ x__ ->
+                       case x__ of
+                           Prelude.Just (Response'Commit x__val) -> Prelude.Just x__val
+                           _otherwise -> Prelude.Nothing)
+                    (\ _ y__ -> Prelude.fmap Response'Commit y__))
+                 (Data.ProtoLens.maybeLens Data.Default.Class.def))
 
 instance Data.Default.Class.Default Response where
-        def
-          = Response{_Response'exception = Prelude.Nothing,
-                     _Response'echo = Prelude.Nothing,
-                     _Response'flush = Prelude.Nothing,
-                     _Response'info = Prelude.Nothing,
-                     _Response'setOption = Prelude.Nothing,
-                     _Response'deliverTx = Prelude.Nothing,
-                     _Response'checkTx = Prelude.Nothing,
-                     _Response'commit = Prelude.Nothing,
-                     _Response'query = Prelude.Nothing,
-                     _Response'initChain = Prelude.Nothing,
-                     _Response'beginBlock = Prelude.Nothing,
-                     _Response'endBlock = Prelude.Nothing}
+        def = Response{_Response'value = Prelude.Nothing}
 
 instance Data.ProtoLens.Message Response where
         descriptor
@@ -1487,23 +2166,11 @@ instance Data.ProtoLens.Message Response where
                          Data.ProtoLens.FieldTypeDescriptor ResponseSetOption)
                       (Data.ProtoLens.OptionalField maybe'setOption)
                       :: Data.ProtoLens.FieldDescriptor Response
-                deliverTx__field_descriptor
-                  = Data.ProtoLens.FieldDescriptor "deliver_tx"
+                initChain__field_descriptor
+                  = Data.ProtoLens.FieldDescriptor "init_chain"
                       (Data.ProtoLens.MessageField ::
-                         Data.ProtoLens.FieldTypeDescriptor ResponseDeliverTx)
-                      (Data.ProtoLens.OptionalField maybe'deliverTx)
-                      :: Data.ProtoLens.FieldDescriptor Response
-                checkTx__field_descriptor
-                  = Data.ProtoLens.FieldDescriptor "check_tx"
-                      (Data.ProtoLens.MessageField ::
-                         Data.ProtoLens.FieldTypeDescriptor ResponseCheckTx)
-                      (Data.ProtoLens.OptionalField maybe'checkTx)
-                      :: Data.ProtoLens.FieldDescriptor Response
-                commit__field_descriptor
-                  = Data.ProtoLens.FieldDescriptor "commit"
-                      (Data.ProtoLens.MessageField ::
-                         Data.ProtoLens.FieldTypeDescriptor ResponseCommit)
-                      (Data.ProtoLens.OptionalField maybe'commit)
+                         Data.ProtoLens.FieldTypeDescriptor ResponseInitChain)
+                      (Data.ProtoLens.OptionalField maybe'initChain)
                       :: Data.ProtoLens.FieldDescriptor Response
                 query__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "query"
@@ -1511,17 +2178,23 @@ instance Data.ProtoLens.Message Response where
                          Data.ProtoLens.FieldTypeDescriptor ResponseQuery)
                       (Data.ProtoLens.OptionalField maybe'query)
                       :: Data.ProtoLens.FieldDescriptor Response
-                initChain__field_descriptor
-                  = Data.ProtoLens.FieldDescriptor "init_chain"
-                      (Data.ProtoLens.MessageField ::
-                         Data.ProtoLens.FieldTypeDescriptor ResponseInitChain)
-                      (Data.ProtoLens.OptionalField maybe'initChain)
-                      :: Data.ProtoLens.FieldDescriptor Response
                 beginBlock__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "begin_block"
                       (Data.ProtoLens.MessageField ::
                          Data.ProtoLens.FieldTypeDescriptor ResponseBeginBlock)
                       (Data.ProtoLens.OptionalField maybe'beginBlock)
+                      :: Data.ProtoLens.FieldDescriptor Response
+                checkTx__field_descriptor
+                  = Data.ProtoLens.FieldDescriptor "check_tx"
+                      (Data.ProtoLens.MessageField ::
+                         Data.ProtoLens.FieldTypeDescriptor ResponseCheckTx)
+                      (Data.ProtoLens.OptionalField maybe'checkTx)
+                      :: Data.ProtoLens.FieldDescriptor Response
+                deliverTx__field_descriptor
+                  = Data.ProtoLens.FieldDescriptor "deliver_tx"
+                      (Data.ProtoLens.MessageField ::
+                         Data.ProtoLens.FieldTypeDescriptor ResponseDeliverTx)
+                      (Data.ProtoLens.OptionalField maybe'deliverTx)
                       :: Data.ProtoLens.FieldDescriptor Response
                 endBlock__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "end_block"
@@ -1529,37 +2202,43 @@ instance Data.ProtoLens.Message Response where
                          Data.ProtoLens.FieldTypeDescriptor ResponseEndBlock)
                       (Data.ProtoLens.OptionalField maybe'endBlock)
                       :: Data.ProtoLens.FieldDescriptor Response
+                commit__field_descriptor
+                  = Data.ProtoLens.FieldDescriptor "commit"
+                      (Data.ProtoLens.MessageField ::
+                         Data.ProtoLens.FieldTypeDescriptor ResponseCommit)
+                      (Data.ProtoLens.OptionalField maybe'commit)
+                      :: Data.ProtoLens.FieldDescriptor Response
               in
-              Data.ProtoLens.MessageDescriptor
+              Data.ProtoLens.MessageDescriptor (Data.Text.pack "types.Response")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 1, exception__field_descriptor),
                     (Data.ProtoLens.Tag 2, echo__field_descriptor),
                     (Data.ProtoLens.Tag 3, flush__field_descriptor),
                     (Data.ProtoLens.Tag 4, info__field_descriptor),
                     (Data.ProtoLens.Tag 5, setOption__field_descriptor),
-                    (Data.ProtoLens.Tag 6, deliverTx__field_descriptor),
-                    (Data.ProtoLens.Tag 7, checkTx__field_descriptor),
-                    (Data.ProtoLens.Tag 8, commit__field_descriptor),
-                    (Data.ProtoLens.Tag 9, query__field_descriptor),
-                    (Data.ProtoLens.Tag 10, initChain__field_descriptor),
-                    (Data.ProtoLens.Tag 11, beginBlock__field_descriptor),
-                    (Data.ProtoLens.Tag 12, endBlock__field_descriptor)])
+                    (Data.ProtoLens.Tag 6, initChain__field_descriptor),
+                    (Data.ProtoLens.Tag 7, query__field_descriptor),
+                    (Data.ProtoLens.Tag 8, beginBlock__field_descriptor),
+                    (Data.ProtoLens.Tag 9, checkTx__field_descriptor),
+                    (Data.ProtoLens.Tag 10, deliverTx__field_descriptor),
+                    (Data.ProtoLens.Tag 11, endBlock__field_descriptor),
+                    (Data.ProtoLens.Tag 12, commit__field_descriptor)])
                 (Data.Map.fromList
                    [("exception", exception__field_descriptor),
                     ("echo", echo__field_descriptor),
                     ("flush", flush__field_descriptor),
                     ("info", info__field_descriptor),
                     ("set_option", setOption__field_descriptor),
-                    ("deliver_tx", deliverTx__field_descriptor),
-                    ("check_tx", checkTx__field_descriptor),
-                    ("commit", commit__field_descriptor),
-                    ("query", query__field_descriptor),
                     ("init_chain", initChain__field_descriptor),
+                    ("query", query__field_descriptor),
                     ("begin_block", beginBlock__field_descriptor),
-                    ("end_block", endBlock__field_descriptor)])
+                    ("check_tx", checkTx__field_descriptor),
+                    ("deliver_tx", deliverTx__field_descriptor),
+                    ("end_block", endBlock__field_descriptor),
+                    ("commit", commit__field_descriptor)])
 
 data ResponseBeginBlock = ResponseBeginBlock{}
-                        deriving (Prelude.Show, Prelude.Eq)
+                        deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
 instance Data.Default.Class.Default ResponseBeginBlock where
         def = ResponseBeginBlock{}
@@ -1567,50 +2246,84 @@ instance Data.Default.Class.Default ResponseBeginBlock where
 instance Data.ProtoLens.Message ResponseBeginBlock where
         descriptor
           = let in
-              Data.ProtoLens.MessageDescriptor (Data.Map.fromList [])
+              Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "types.ResponseBeginBlock")
+                (Data.Map.fromList [])
                 (Data.Map.fromList [])
 
 data ResponseCheckTx = ResponseCheckTx{_ResponseCheckTx'code ::
-                                       !CodeType,
+                                       !Data.Word.Word32,
                                        _ResponseCheckTx'data' :: !Data.ByteString.ByteString,
-                                       _ResponseCheckTx'log :: !Data.Text.Text}
-                     deriving (Prelude.Show, Prelude.Eq)
+                                       _ResponseCheckTx'log :: !Data.Text.Text,
+                                       _ResponseCheckTx'gas :: !Data.Int.Int64,
+                                       _ResponseCheckTx'fee :: !Data.Int.Int64}
+                     deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
-instance (a ~ CodeType, b ~ CodeType, Prelude.Functor f) =>
+instance (a ~ Data.Word.Word32, b ~ Data.Word.Word32,
+          Prelude.Functor f) =>
          Lens.Labels.HasLens "code" f ResponseCheckTx ResponseCheckTx a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _ResponseCheckTx'code
-              (\ x__ y__ -> x__{_ResponseCheckTx'code = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _ResponseCheckTx'code
+                 (\ x__ y__ -> x__{_ResponseCheckTx'code = y__}))
+              Prelude.id
 
 instance (a ~ Data.ByteString.ByteString,
           b ~ Data.ByteString.ByteString, Prelude.Functor f) =>
          Lens.Labels.HasLens "data'" f ResponseCheckTx ResponseCheckTx a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _ResponseCheckTx'data'
-              (\ x__ y__ -> x__{_ResponseCheckTx'data' = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _ResponseCheckTx'data'
+                 (\ x__ y__ -> x__{_ResponseCheckTx'data' = y__}))
+              Prelude.id
 
 instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
           Prelude.Functor f) =>
          Lens.Labels.HasLens "log" f ResponseCheckTx ResponseCheckTx a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _ResponseCheckTx'log
-              (\ x__ y__ -> x__{_ResponseCheckTx'log = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _ResponseCheckTx'log
+                 (\ x__ y__ -> x__{_ResponseCheckTx'log = y__}))
+              Prelude.id
+
+instance (a ~ Data.Int.Int64, b ~ Data.Int.Int64,
+          Prelude.Functor f) =>
+         Lens.Labels.HasLens "gas" f ResponseCheckTx ResponseCheckTx a b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _ResponseCheckTx'gas
+                 (\ x__ y__ -> x__{_ResponseCheckTx'gas = y__}))
+              Prelude.id
+
+instance (a ~ Data.Int.Int64, b ~ Data.Int.Int64,
+          Prelude.Functor f) =>
+         Lens.Labels.HasLens "fee" f ResponseCheckTx ResponseCheckTx a b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _ResponseCheckTx'fee
+                 (\ x__ y__ -> x__{_ResponseCheckTx'fee = y__}))
+              Prelude.id
 
 instance Data.Default.Class.Default ResponseCheckTx where
         def
-          = ResponseCheckTx{_ResponseCheckTx'code = Data.Default.Class.def,
+          = ResponseCheckTx{_ResponseCheckTx'code =
+                              Data.ProtoLens.fieldDefault,
                             _ResponseCheckTx'data' = Data.ProtoLens.fieldDefault,
-                            _ResponseCheckTx'log = Data.ProtoLens.fieldDefault}
+                            _ResponseCheckTx'log = Data.ProtoLens.fieldDefault,
+                            _ResponseCheckTx'gas = Data.ProtoLens.fieldDefault,
+                            _ResponseCheckTx'fee = Data.ProtoLens.fieldDefault}
 
 instance Data.ProtoLens.Message ResponseCheckTx where
         descriptor
           = let code__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "code"
-                      (Data.ProtoLens.EnumField ::
-                         Data.ProtoLens.FieldTypeDescriptor CodeType)
+                      (Data.ProtoLens.UInt32Field ::
+                         Data.ProtoLens.FieldTypeDescriptor Data.Word.Word32)
                       (Data.ProtoLens.PlainField Data.ProtoLens.Optional code)
                       :: Data.ProtoLens.FieldDescriptor ResponseCheckTx
                 data'__field_descriptor
@@ -1625,48 +2338,72 @@ instance Data.ProtoLens.Message ResponseCheckTx where
                          Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
                       (Data.ProtoLens.PlainField Data.ProtoLens.Optional log)
                       :: Data.ProtoLens.FieldDescriptor ResponseCheckTx
+                gas__field_descriptor
+                  = Data.ProtoLens.FieldDescriptor "gas"
+                      (Data.ProtoLens.Int64Field ::
+                         Data.ProtoLens.FieldTypeDescriptor Data.Int.Int64)
+                      (Data.ProtoLens.PlainField Data.ProtoLens.Optional gas)
+                      :: Data.ProtoLens.FieldDescriptor ResponseCheckTx
+                fee__field_descriptor
+                  = Data.ProtoLens.FieldDescriptor "fee"
+                      (Data.ProtoLens.Int64Field ::
+                         Data.ProtoLens.FieldTypeDescriptor Data.Int.Int64)
+                      (Data.ProtoLens.PlainField Data.ProtoLens.Optional fee)
+                      :: Data.ProtoLens.FieldDescriptor ResponseCheckTx
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "types.ResponseCheckTx")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 1, code__field_descriptor),
                     (Data.ProtoLens.Tag 2, data'__field_descriptor),
-                    (Data.ProtoLens.Tag 3, log__field_descriptor)])
+                    (Data.ProtoLens.Tag 3, log__field_descriptor),
+                    (Data.ProtoLens.Tag 4, gas__field_descriptor),
+                    (Data.ProtoLens.Tag 5, fee__field_descriptor)])
                 (Data.Map.fromList
                    [("code", code__field_descriptor),
-                    ("data", data'__field_descriptor), ("log", log__field_descriptor)])
+                    ("data", data'__field_descriptor), ("log", log__field_descriptor),
+                    ("gas", gas__field_descriptor), ("fee", fee__field_descriptor)])
 
 data ResponseCommit = ResponseCommit{_ResponseCommit'code ::
-                                     !CodeType,
+                                     !Data.Word.Word32,
                                      _ResponseCommit'data' :: !Data.ByteString.ByteString,
                                      _ResponseCommit'log :: !Data.Text.Text}
-                    deriving (Prelude.Show, Prelude.Eq)
+                    deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
-instance (a ~ CodeType, b ~ CodeType, Prelude.Functor f) =>
+instance (a ~ Data.Word.Word32, b ~ Data.Word.Word32,
+          Prelude.Functor f) =>
          Lens.Labels.HasLens "code" f ResponseCommit ResponseCommit a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _ResponseCommit'code
-              (\ x__ y__ -> x__{_ResponseCommit'code = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _ResponseCommit'code
+                 (\ x__ y__ -> x__{_ResponseCommit'code = y__}))
+              Prelude.id
 
 instance (a ~ Data.ByteString.ByteString,
           b ~ Data.ByteString.ByteString, Prelude.Functor f) =>
          Lens.Labels.HasLens "data'" f ResponseCommit ResponseCommit a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _ResponseCommit'data'
-              (\ x__ y__ -> x__{_ResponseCommit'data' = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _ResponseCommit'data'
+                 (\ x__ y__ -> x__{_ResponseCommit'data' = y__}))
+              Prelude.id
 
 instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
           Prelude.Functor f) =>
          Lens.Labels.HasLens "log" f ResponseCommit ResponseCommit a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _ResponseCommit'log
-              (\ x__ y__ -> x__{_ResponseCommit'log = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _ResponseCommit'log
+                 (\ x__ y__ -> x__{_ResponseCommit'log = y__}))
+              Prelude.id
 
 instance Data.Default.Class.Default ResponseCommit where
         def
-          = ResponseCommit{_ResponseCommit'code = Data.Default.Class.def,
+          = ResponseCommit{_ResponseCommit'code =
+                             Data.ProtoLens.fieldDefault,
                            _ResponseCommit'data' = Data.ProtoLens.fieldDefault,
                            _ResponseCommit'log = Data.ProtoLens.fieldDefault}
 
@@ -1674,8 +2411,8 @@ instance Data.ProtoLens.Message ResponseCommit where
         descriptor
           = let code__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "code"
-                      (Data.ProtoLens.EnumField ::
-                         Data.ProtoLens.FieldTypeDescriptor CodeType)
+                      (Data.ProtoLens.UInt32Field ::
+                         Data.ProtoLens.FieldTypeDescriptor Data.Word.Word32)
                       (Data.ProtoLens.PlainField Data.ProtoLens.Optional code)
                       :: Data.ProtoLens.FieldDescriptor ResponseCommit
                 data'__field_descriptor
@@ -1692,6 +2429,7 @@ instance Data.ProtoLens.Message ResponseCommit where
                       :: Data.ProtoLens.FieldDescriptor ResponseCommit
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "types.ResponseCommit")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 1, code__field_descriptor),
                     (Data.ProtoLens.Tag 2, data'__field_descriptor),
@@ -1701,18 +2439,22 @@ instance Data.ProtoLens.Message ResponseCommit where
                     ("data", data'__field_descriptor), ("log", log__field_descriptor)])
 
 data ResponseDeliverTx = ResponseDeliverTx{_ResponseDeliverTx'code
-                                           :: !CodeType,
+                                           :: !Data.Word.Word32,
                                            _ResponseDeliverTx'data' :: !Data.ByteString.ByteString,
-                                           _ResponseDeliverTx'log :: !Data.Text.Text}
-                       deriving (Prelude.Show, Prelude.Eq)
+                                           _ResponseDeliverTx'log :: !Data.Text.Text,
+                                           _ResponseDeliverTx'tags :: ![KVPair]}
+                       deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
-instance (a ~ CodeType, b ~ CodeType, Prelude.Functor f) =>
+instance (a ~ Data.Word.Word32, b ~ Data.Word.Word32,
+          Prelude.Functor f) =>
          Lens.Labels.HasLens "code" f ResponseDeliverTx ResponseDeliverTx a
            b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _ResponseDeliverTx'code
-              (\ x__ y__ -> x__{_ResponseDeliverTx'code = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _ResponseDeliverTx'code
+                 (\ x__ y__ -> x__{_ResponseDeliverTx'code = y__}))
+              Prelude.id
 
 instance (a ~ Data.ByteString.ByteString,
           b ~ Data.ByteString.ByteString, Prelude.Functor f) =>
@@ -1720,30 +2462,45 @@ instance (a ~ Data.ByteString.ByteString,
            b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _ResponseDeliverTx'data'
-              (\ x__ y__ -> x__{_ResponseDeliverTx'data' = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _ResponseDeliverTx'data'
+                 (\ x__ y__ -> x__{_ResponseDeliverTx'data' = y__}))
+              Prelude.id
 
 instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
           Prelude.Functor f) =>
          Lens.Labels.HasLens "log" f ResponseDeliverTx ResponseDeliverTx a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _ResponseDeliverTx'log
-              (\ x__ y__ -> x__{_ResponseDeliverTx'log = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _ResponseDeliverTx'log
+                 (\ x__ y__ -> x__{_ResponseDeliverTx'log = y__}))
+              Prelude.id
+
+instance (a ~ [KVPair], b ~ [KVPair], Prelude.Functor f) =>
+         Lens.Labels.HasLens "tags" f ResponseDeliverTx ResponseDeliverTx a
+           b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _ResponseDeliverTx'tags
+                 (\ x__ y__ -> x__{_ResponseDeliverTx'tags = y__}))
+              Prelude.id
 
 instance Data.Default.Class.Default ResponseDeliverTx where
         def
           = ResponseDeliverTx{_ResponseDeliverTx'code =
-                                Data.Default.Class.def,
+                                Data.ProtoLens.fieldDefault,
                               _ResponseDeliverTx'data' = Data.ProtoLens.fieldDefault,
-                              _ResponseDeliverTx'log = Data.ProtoLens.fieldDefault}
+                              _ResponseDeliverTx'log = Data.ProtoLens.fieldDefault,
+                              _ResponseDeliverTx'tags = []}
 
 instance Data.ProtoLens.Message ResponseDeliverTx where
         descriptor
           = let code__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "code"
-                      (Data.ProtoLens.EnumField ::
-                         Data.ProtoLens.FieldTypeDescriptor CodeType)
+                      (Data.ProtoLens.UInt32Field ::
+                         Data.ProtoLens.FieldTypeDescriptor Data.Word.Word32)
                       (Data.ProtoLens.PlainField Data.ProtoLens.Optional code)
                       :: Data.ProtoLens.FieldDescriptor ResponseDeliverTx
                 data'__field_descriptor
@@ -1758,27 +2515,38 @@ instance Data.ProtoLens.Message ResponseDeliverTx where
                          Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
                       (Data.ProtoLens.PlainField Data.ProtoLens.Optional log)
                       :: Data.ProtoLens.FieldDescriptor ResponseDeliverTx
+                tags__field_descriptor
+                  = Data.ProtoLens.FieldDescriptor "tags"
+                      (Data.ProtoLens.MessageField ::
+                         Data.ProtoLens.FieldTypeDescriptor KVPair)
+                      (Data.ProtoLens.RepeatedField Data.ProtoLens.Unpacked tags)
+                      :: Data.ProtoLens.FieldDescriptor ResponseDeliverTx
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "types.ResponseDeliverTx")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 1, code__field_descriptor),
                     (Data.ProtoLens.Tag 2, data'__field_descriptor),
-                    (Data.ProtoLens.Tag 3, log__field_descriptor)])
+                    (Data.ProtoLens.Tag 3, log__field_descriptor),
+                    (Data.ProtoLens.Tag 4, tags__field_descriptor)])
                 (Data.Map.fromList
                    [("code", code__field_descriptor),
-                    ("data", data'__field_descriptor), ("log", log__field_descriptor)])
+                    ("data", data'__field_descriptor), ("log", log__field_descriptor),
+                    ("tags", tags__field_descriptor)])
 
 data ResponseEcho = ResponseEcho{_ResponseEcho'message ::
                                  !Data.Text.Text}
-                  deriving (Prelude.Show, Prelude.Eq)
+                  deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
 instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
           Prelude.Functor f) =>
          Lens.Labels.HasLens "message" f ResponseEcho ResponseEcho a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _ResponseEcho'message
-              (\ x__ y__ -> x__{_ResponseEcho'message = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _ResponseEcho'message
+                 (\ x__ y__ -> x__{_ResponseEcho'message = y__}))
+              Prelude.id
 
 instance Data.Default.Class.Default ResponseEcho where
         def
@@ -1794,41 +2562,92 @@ instance Data.ProtoLens.Message ResponseEcho where
                       :: Data.ProtoLens.FieldDescriptor ResponseEcho
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "types.ResponseEcho")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 1, message__field_descriptor)])
                 (Data.Map.fromList [("message", message__field_descriptor)])
 
-data ResponseEndBlock = ResponseEndBlock{_ResponseEndBlock'diffs ::
-                                         ![Validator]}
-                      deriving (Prelude.Show, Prelude.Eq)
+data ResponseEndBlock = ResponseEndBlock{_ResponseEndBlock'validatorUpdates
+                                         :: ![Validator],
+                                         _ResponseEndBlock'consensusParamUpdates ::
+                                         !(Prelude.Maybe ConsensusParams)}
+                      deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
 instance (a ~ [Validator], b ~ [Validator], Prelude.Functor f) =>
-         Lens.Labels.HasLens "diffs" f ResponseEndBlock ResponseEndBlock a b
+         Lens.Labels.HasLens "validatorUpdates" f ResponseEndBlock
+           ResponseEndBlock
+           a
+           b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _ResponseEndBlock'diffs
-              (\ x__ y__ -> x__{_ResponseEndBlock'diffs = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _ResponseEndBlock'validatorUpdates
+                 (\ x__ y__ -> x__{_ResponseEndBlock'validatorUpdates = y__}))
+              Prelude.id
+
+instance (a ~ ConsensusParams, b ~ ConsensusParams,
+          Prelude.Functor f) =>
+         Lens.Labels.HasLens "consensusParamUpdates" f ResponseEndBlock
+           ResponseEndBlock
+           a
+           b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens
+                 _ResponseEndBlock'consensusParamUpdates
+                 (\ x__ y__ -> x__{_ResponseEndBlock'consensusParamUpdates = y__}))
+              (Data.ProtoLens.maybeLens Data.Default.Class.def)
+
+instance (a ~ Prelude.Maybe ConsensusParams,
+          b ~ Prelude.Maybe ConsensusParams, Prelude.Functor f) =>
+         Lens.Labels.HasLens "maybe'consensusParamUpdates" f
+           ResponseEndBlock
+           ResponseEndBlock
+           a
+           b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens
+                 _ResponseEndBlock'consensusParamUpdates
+                 (\ x__ y__ -> x__{_ResponseEndBlock'consensusParamUpdates = y__}))
+              Prelude.id
 
 instance Data.Default.Class.Default ResponseEndBlock where
-        def = ResponseEndBlock{_ResponseEndBlock'diffs = []}
+        def
+          = ResponseEndBlock{_ResponseEndBlock'validatorUpdates = [],
+                             _ResponseEndBlock'consensusParamUpdates = Prelude.Nothing}
 
 instance Data.ProtoLens.Message ResponseEndBlock where
         descriptor
-          = let diffs__field_descriptor
-                  = Data.ProtoLens.FieldDescriptor "diffs"
+          = let validatorUpdates__field_descriptor
+                  = Data.ProtoLens.FieldDescriptor "validator_updates"
                       (Data.ProtoLens.MessageField ::
                          Data.ProtoLens.FieldTypeDescriptor Validator)
-                      (Data.ProtoLens.RepeatedField Data.ProtoLens.Unpacked diffs)
+                      (Data.ProtoLens.RepeatedField Data.ProtoLens.Unpacked
+                         validatorUpdates)
+                      :: Data.ProtoLens.FieldDescriptor ResponseEndBlock
+                consensusParamUpdates__field_descriptor
+                  = Data.ProtoLens.FieldDescriptor "consensus_param_updates"
+                      (Data.ProtoLens.MessageField ::
+                         Data.ProtoLens.FieldTypeDescriptor ConsensusParams)
+                      (Data.ProtoLens.OptionalField maybe'consensusParamUpdates)
                       :: Data.ProtoLens.FieldDescriptor ResponseEndBlock
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "types.ResponseEndBlock")
                 (Data.Map.fromList
-                   [(Data.ProtoLens.Tag 1, diffs__field_descriptor)])
-                (Data.Map.fromList [("diffs", diffs__field_descriptor)])
+                   [(Data.ProtoLens.Tag 1, validatorUpdates__field_descriptor),
+                    (Data.ProtoLens.Tag 2, consensusParamUpdates__field_descriptor)])
+                (Data.Map.fromList
+                   [("validator_updates", validatorUpdates__field_descriptor),
+                    ("consensus_param_updates",
+                     consensusParamUpdates__field_descriptor)])
 
 data ResponseException = ResponseException{_ResponseException'error
                                            :: !Data.Text.Text}
-                       deriving (Prelude.Show, Prelude.Eq)
+                       deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
 instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
           Prelude.Functor f) =>
@@ -1836,8 +2655,10 @@ instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
            b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _ResponseException'error
-              (\ x__ y__ -> x__{_ResponseException'error = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _ResponseException'error
+                 (\ x__ y__ -> x__{_ResponseException'error = y__}))
+              Prelude.id
 
 instance Data.Default.Class.Default ResponseException where
         def
@@ -1854,12 +2675,13 @@ instance Data.ProtoLens.Message ResponseException where
                       :: Data.ProtoLens.FieldDescriptor ResponseException
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "types.ResponseException")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 1, error__field_descriptor)])
                 (Data.Map.fromList [("error", error__field_descriptor)])
 
 data ResponseFlush = ResponseFlush{}
-                   deriving (Prelude.Show, Prelude.Eq)
+                   deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
 instance Data.Default.Class.Default ResponseFlush where
         def = ResponseFlush{}
@@ -1867,40 +2689,48 @@ instance Data.Default.Class.Default ResponseFlush where
 instance Data.ProtoLens.Message ResponseFlush where
         descriptor
           = let in
-              Data.ProtoLens.MessageDescriptor (Data.Map.fromList [])
+              Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "types.ResponseFlush")
+                (Data.Map.fromList [])
                 (Data.Map.fromList [])
 
 data ResponseInfo = ResponseInfo{_ResponseInfo'data' ::
                                  !Data.Text.Text,
                                  _ResponseInfo'version :: !Data.Text.Text,
-                                 _ResponseInfo'lastBlockHeight :: !Data.Word.Word64,
+                                 _ResponseInfo'lastBlockHeight :: !Data.Int.Int64,
                                  _ResponseInfo'lastBlockAppHash :: !Data.ByteString.ByteString}
-                  deriving (Prelude.Show, Prelude.Eq)
+                  deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
 instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
           Prelude.Functor f) =>
          Lens.Labels.HasLens "data'" f ResponseInfo ResponseInfo a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _ResponseInfo'data'
-              (\ x__ y__ -> x__{_ResponseInfo'data' = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _ResponseInfo'data'
+                 (\ x__ y__ -> x__{_ResponseInfo'data' = y__}))
+              Prelude.id
 
 instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
           Prelude.Functor f) =>
          Lens.Labels.HasLens "version" f ResponseInfo ResponseInfo a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _ResponseInfo'version
-              (\ x__ y__ -> x__{_ResponseInfo'version = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _ResponseInfo'version
+                 (\ x__ y__ -> x__{_ResponseInfo'version = y__}))
+              Prelude.id
 
-instance (a ~ Data.Word.Word64, b ~ Data.Word.Word64,
+instance (a ~ Data.Int.Int64, b ~ Data.Int.Int64,
           Prelude.Functor f) =>
          Lens.Labels.HasLens "lastBlockHeight" f ResponseInfo ResponseInfo a
            b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _ResponseInfo'lastBlockHeight
-              (\ x__ y__ -> x__{_ResponseInfo'lastBlockHeight = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _ResponseInfo'lastBlockHeight
+                 (\ x__ y__ -> x__{_ResponseInfo'lastBlockHeight = y__}))
+              Prelude.id
 
 instance (a ~ Data.ByteString.ByteString,
           b ~ Data.ByteString.ByteString, Prelude.Functor f) =>
@@ -1909,8 +2739,10 @@ instance (a ~ Data.ByteString.ByteString,
            b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _ResponseInfo'lastBlockAppHash
-              (\ x__ y__ -> x__{_ResponseInfo'lastBlockAppHash = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _ResponseInfo'lastBlockAppHash
+                 (\ x__ y__ -> x__{_ResponseInfo'lastBlockAppHash = y__}))
+              Prelude.id
 
 instance Data.Default.Class.Default ResponseInfo where
         def
@@ -1935,8 +2767,8 @@ instance Data.ProtoLens.Message ResponseInfo where
                       :: Data.ProtoLens.FieldDescriptor ResponseInfo
                 lastBlockHeight__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "last_block_height"
-                      (Data.ProtoLens.UInt64Field ::
-                         Data.ProtoLens.FieldTypeDescriptor Data.Word.Word64)
+                      (Data.ProtoLens.Int64Field ::
+                         Data.ProtoLens.FieldTypeDescriptor Data.Int.Int64)
                       (Data.ProtoLens.PlainField Data.ProtoLens.Optional lastBlockHeight)
                       :: Data.ProtoLens.FieldDescriptor ResponseInfo
                 lastBlockAppHash__field_descriptor
@@ -1948,6 +2780,7 @@ instance Data.ProtoLens.Message ResponseInfo where
                       :: Data.ProtoLens.FieldDescriptor ResponseInfo
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "types.ResponseInfo")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 1, data'__field_descriptor),
                     (Data.ProtoLens.Tag 2, version__field_descriptor),
@@ -1960,7 +2793,7 @@ instance Data.ProtoLens.Message ResponseInfo where
                     ("last_block_app_hash", lastBlockAppHash__field_descriptor)])
 
 data ResponseInitChain = ResponseInitChain{}
-                       deriving (Prelude.Show, Prelude.Eq)
+                       deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
 instance Data.Default.Class.Default ResponseInitChain where
         def = ResponseInitChain{}
@@ -1968,77 +2801,94 @@ instance Data.Default.Class.Default ResponseInitChain where
 instance Data.ProtoLens.Message ResponseInitChain where
         descriptor
           = let in
-              Data.ProtoLens.MessageDescriptor (Data.Map.fromList [])
+              Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "types.ResponseInitChain")
+                (Data.Map.fromList [])
                 (Data.Map.fromList [])
 
 data ResponseQuery = ResponseQuery{_ResponseQuery'code ::
-                                   !CodeType,
+                                   !Data.Word.Word32,
                                    _ResponseQuery'index :: !Data.Int.Int64,
                                    _ResponseQuery'key :: !Data.ByteString.ByteString,
                                    _ResponseQuery'value :: !Data.ByteString.ByteString,
                                    _ResponseQuery'proof :: !Data.ByteString.ByteString,
-                                   _ResponseQuery'height :: !Data.Word.Word64,
+                                   _ResponseQuery'height :: !Data.Int.Int64,
                                    _ResponseQuery'log :: !Data.Text.Text}
-                   deriving (Prelude.Show, Prelude.Eq)
+                   deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
-instance (a ~ CodeType, b ~ CodeType, Prelude.Functor f) =>
+instance (a ~ Data.Word.Word32, b ~ Data.Word.Word32,
+          Prelude.Functor f) =>
          Lens.Labels.HasLens "code" f ResponseQuery ResponseQuery a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _ResponseQuery'code
-              (\ x__ y__ -> x__{_ResponseQuery'code = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _ResponseQuery'code
+                 (\ x__ y__ -> x__{_ResponseQuery'code = y__}))
+              Prelude.id
 
 instance (a ~ Data.Int.Int64, b ~ Data.Int.Int64,
           Prelude.Functor f) =>
          Lens.Labels.HasLens "index" f ResponseQuery ResponseQuery a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _ResponseQuery'index
-              (\ x__ y__ -> x__{_ResponseQuery'index = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _ResponseQuery'index
+                 (\ x__ y__ -> x__{_ResponseQuery'index = y__}))
+              Prelude.id
 
 instance (a ~ Data.ByteString.ByteString,
           b ~ Data.ByteString.ByteString, Prelude.Functor f) =>
          Lens.Labels.HasLens "key" f ResponseQuery ResponseQuery a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _ResponseQuery'key
-              (\ x__ y__ -> x__{_ResponseQuery'key = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _ResponseQuery'key
+                 (\ x__ y__ -> x__{_ResponseQuery'key = y__}))
+              Prelude.id
 
 instance (a ~ Data.ByteString.ByteString,
           b ~ Data.ByteString.ByteString, Prelude.Functor f) =>
          Lens.Labels.HasLens "value" f ResponseQuery ResponseQuery a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _ResponseQuery'value
-              (\ x__ y__ -> x__{_ResponseQuery'value = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _ResponseQuery'value
+                 (\ x__ y__ -> x__{_ResponseQuery'value = y__}))
+              Prelude.id
 
 instance (a ~ Data.ByteString.ByteString,
           b ~ Data.ByteString.ByteString, Prelude.Functor f) =>
          Lens.Labels.HasLens "proof" f ResponseQuery ResponseQuery a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _ResponseQuery'proof
-              (\ x__ y__ -> x__{_ResponseQuery'proof = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _ResponseQuery'proof
+                 (\ x__ y__ -> x__{_ResponseQuery'proof = y__}))
+              Prelude.id
 
-instance (a ~ Data.Word.Word64, b ~ Data.Word.Word64,
+instance (a ~ Data.Int.Int64, b ~ Data.Int.Int64,
           Prelude.Functor f) =>
          Lens.Labels.HasLens "height" f ResponseQuery ResponseQuery a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _ResponseQuery'height
-              (\ x__ y__ -> x__{_ResponseQuery'height = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _ResponseQuery'height
+                 (\ x__ y__ -> x__{_ResponseQuery'height = y__}))
+              Prelude.id
 
 instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
           Prelude.Functor f) =>
          Lens.Labels.HasLens "log" f ResponseQuery ResponseQuery a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _ResponseQuery'log
-              (\ x__ y__ -> x__{_ResponseQuery'log = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _ResponseQuery'log
+                 (\ x__ y__ -> x__{_ResponseQuery'log = y__}))
+              Prelude.id
 
 instance Data.Default.Class.Default ResponseQuery where
         def
-          = ResponseQuery{_ResponseQuery'code = Data.Default.Class.def,
+          = ResponseQuery{_ResponseQuery'code = Data.ProtoLens.fieldDefault,
                           _ResponseQuery'index = Data.ProtoLens.fieldDefault,
                           _ResponseQuery'key = Data.ProtoLens.fieldDefault,
                           _ResponseQuery'value = Data.ProtoLens.fieldDefault,
@@ -2050,8 +2900,8 @@ instance Data.ProtoLens.Message ResponseQuery where
         descriptor
           = let code__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "code"
-                      (Data.ProtoLens.EnumField ::
-                         Data.ProtoLens.FieldTypeDescriptor CodeType)
+                      (Data.ProtoLens.UInt32Field ::
+                         Data.ProtoLens.FieldTypeDescriptor Data.Word.Word32)
                       (Data.ProtoLens.PlainField Data.ProtoLens.Optional code)
                       :: Data.ProtoLens.FieldDescriptor ResponseQuery
                 index__field_descriptor
@@ -2080,8 +2930,8 @@ instance Data.ProtoLens.Message ResponseQuery where
                       :: Data.ProtoLens.FieldDescriptor ResponseQuery
                 height__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "height"
-                      (Data.ProtoLens.UInt64Field ::
-                         Data.ProtoLens.FieldTypeDescriptor Data.Word.Word64)
+                      (Data.ProtoLens.Int64Field ::
+                         Data.ProtoLens.FieldTypeDescriptor Data.Int.Int64)
                       (Data.ProtoLens.PlainField Data.ProtoLens.Optional height)
                       :: Data.ProtoLens.FieldDescriptor ResponseQuery
                 log__field_descriptor
@@ -2092,6 +2942,7 @@ instance Data.ProtoLens.Message ResponseQuery where
                       :: Data.ProtoLens.FieldDescriptor ResponseQuery
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "types.ResponseQuery")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 1, code__field_descriptor),
                     (Data.ProtoLens.Tag 2, index__field_descriptor),
@@ -2108,26 +2959,47 @@ instance Data.ProtoLens.Message ResponseQuery where
                     ("height", height__field_descriptor),
                     ("log", log__field_descriptor)])
 
-data ResponseSetOption = ResponseSetOption{_ResponseSetOption'log
-                                           :: !Data.Text.Text}
-                       deriving (Prelude.Show, Prelude.Eq)
+data ResponseSetOption = ResponseSetOption{_ResponseSetOption'code
+                                           :: !Data.Word.Word32,
+                                           _ResponseSetOption'log :: !Data.Text.Text}
+                       deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
+
+instance (a ~ Data.Word.Word32, b ~ Data.Word.Word32,
+          Prelude.Functor f) =>
+         Lens.Labels.HasLens "code" f ResponseSetOption ResponseSetOption a
+           b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _ResponseSetOption'code
+                 (\ x__ y__ -> x__{_ResponseSetOption'code = y__}))
+              Prelude.id
 
 instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
           Prelude.Functor f) =>
          Lens.Labels.HasLens "log" f ResponseSetOption ResponseSetOption a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _ResponseSetOption'log
-              (\ x__ y__ -> x__{_ResponseSetOption'log = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _ResponseSetOption'log
+                 (\ x__ y__ -> x__{_ResponseSetOption'log = y__}))
+              Prelude.id
 
 instance Data.Default.Class.Default ResponseSetOption where
         def
-          = ResponseSetOption{_ResponseSetOption'log =
-                                Data.ProtoLens.fieldDefault}
+          = ResponseSetOption{_ResponseSetOption'code =
+                                Data.ProtoLens.fieldDefault,
+                              _ResponseSetOption'log = Data.ProtoLens.fieldDefault}
 
 instance Data.ProtoLens.Message ResponseSetOption where
         descriptor
-          = let log__field_descriptor
+          = let code__field_descriptor
+                  = Data.ProtoLens.FieldDescriptor "code"
+                      (Data.ProtoLens.UInt32Field ::
+                         Data.ProtoLens.FieldTypeDescriptor Data.Word.Word32)
+                      (Data.ProtoLens.PlainField Data.ProtoLens.Optional code)
+                      :: Data.ProtoLens.FieldDescriptor ResponseSetOption
+                log__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "log"
                       (Data.ProtoLens.StringField ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
@@ -2135,29 +3007,89 @@ instance Data.ProtoLens.Message ResponseSetOption where
                       :: Data.ProtoLens.FieldDescriptor ResponseSetOption
               in
               Data.ProtoLens.MessageDescriptor
-                (Data.Map.fromList [(Data.ProtoLens.Tag 1, log__field_descriptor)])
-                (Data.Map.fromList [("log", log__field_descriptor)])
+                (Data.Text.pack "types.ResponseSetOption")
+                (Data.Map.fromList
+                   [(Data.ProtoLens.Tag 1, code__field_descriptor),
+                    (Data.ProtoLens.Tag 2, log__field_descriptor)])
+                (Data.Map.fromList
+                   [("code", code__field_descriptor), ("log", log__field_descriptor)])
+
+data TxSize = TxSize{_TxSize'maxBytes :: !Data.Int.Int32,
+                     _TxSize'maxGas :: !Data.Int.Int64}
+            deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
+
+instance (a ~ Data.Int.Int32, b ~ Data.Int.Int32,
+          Prelude.Functor f) =>
+         Lens.Labels.HasLens "maxBytes" f TxSize TxSize a b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _TxSize'maxBytes
+                 (\ x__ y__ -> x__{_TxSize'maxBytes = y__}))
+              Prelude.id
+
+instance (a ~ Data.Int.Int64, b ~ Data.Int.Int64,
+          Prelude.Functor f) =>
+         Lens.Labels.HasLens "maxGas" f TxSize TxSize a b
+         where
+        lensOf _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _TxSize'maxGas
+                 (\ x__ y__ -> x__{_TxSize'maxGas = y__}))
+              Prelude.id
+
+instance Data.Default.Class.Default TxSize where
+        def
+          = TxSize{_TxSize'maxBytes = Data.ProtoLens.fieldDefault,
+                   _TxSize'maxGas = Data.ProtoLens.fieldDefault}
+
+instance Data.ProtoLens.Message TxSize where
+        descriptor
+          = let maxBytes__field_descriptor
+                  = Data.ProtoLens.FieldDescriptor "max_bytes"
+                      (Data.ProtoLens.Int32Field ::
+                         Data.ProtoLens.FieldTypeDescriptor Data.Int.Int32)
+                      (Data.ProtoLens.PlainField Data.ProtoLens.Optional maxBytes)
+                      :: Data.ProtoLens.FieldDescriptor TxSize
+                maxGas__field_descriptor
+                  = Data.ProtoLens.FieldDescriptor "max_gas"
+                      (Data.ProtoLens.Int64Field ::
+                         Data.ProtoLens.FieldTypeDescriptor Data.Int.Int64)
+                      (Data.ProtoLens.PlainField Data.ProtoLens.Optional maxGas)
+                      :: Data.ProtoLens.FieldDescriptor TxSize
+              in
+              Data.ProtoLens.MessageDescriptor (Data.Text.pack "types.TxSize")
+                (Data.Map.fromList
+                   [(Data.ProtoLens.Tag 1, maxBytes__field_descriptor),
+                    (Data.ProtoLens.Tag 2, maxGas__field_descriptor)])
+                (Data.Map.fromList
+                   [("max_bytes", maxBytes__field_descriptor),
+                    ("max_gas", maxGas__field_descriptor)])
 
 data Validator = Validator{_Validator'pubKey ::
                            !Data.ByteString.ByteString,
-                           _Validator'power :: !Data.Word.Word64}
-               deriving (Prelude.Show, Prelude.Eq)
+                           _Validator'power :: !Data.Int.Int64}
+               deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
 instance (a ~ Data.ByteString.ByteString,
           b ~ Data.ByteString.ByteString, Prelude.Functor f) =>
          Lens.Labels.HasLens "pubKey" f Validator Validator a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _Validator'pubKey
-              (\ x__ y__ -> x__{_Validator'pubKey = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Validator'pubKey
+                 (\ x__ y__ -> x__{_Validator'pubKey = y__}))
+              Prelude.id
 
-instance (a ~ Data.Word.Word64, b ~ Data.Word.Word64,
+instance (a ~ Data.Int.Int64, b ~ Data.Int.Int64,
           Prelude.Functor f) =>
          Lens.Labels.HasLens "power" f Validator Validator a b
          where
         lensOf _
-          = Lens.Family2.Unchecked.lens _Validator'power
-              (\ x__ y__ -> x__{_Validator'power = y__})
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _Validator'power
+                 (\ x__ y__ -> x__{_Validator'power = y__}))
+              Prelude.id
 
 instance Data.Default.Class.Default Validator where
         def
@@ -2167,25 +3099,33 @@ instance Data.Default.Class.Default Validator where
 instance Data.ProtoLens.Message Validator where
         descriptor
           = let pubKey__field_descriptor
-                  = Data.ProtoLens.FieldDescriptor "pubKey"
+                  = Data.ProtoLens.FieldDescriptor "pub_key"
                       (Data.ProtoLens.BytesField ::
                          Data.ProtoLens.FieldTypeDescriptor Data.ByteString.ByteString)
                       (Data.ProtoLens.PlainField Data.ProtoLens.Optional pubKey)
                       :: Data.ProtoLens.FieldDescriptor Validator
                 power__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "power"
-                      (Data.ProtoLens.UInt64Field ::
-                         Data.ProtoLens.FieldTypeDescriptor Data.Word.Word64)
+                      (Data.ProtoLens.Int64Field ::
+                         Data.ProtoLens.FieldTypeDescriptor Data.Int.Int64)
                       (Data.ProtoLens.PlainField Data.ProtoLens.Optional power)
                       :: Data.ProtoLens.FieldDescriptor Validator
               in
-              Data.ProtoLens.MessageDescriptor
+              Data.ProtoLens.MessageDescriptor (Data.Text.pack "types.Validator")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 1, pubKey__field_descriptor),
                     (Data.ProtoLens.Tag 2, power__field_descriptor)])
                 (Data.Map.fromList
-                   [("pubKey", pubKey__field_descriptor),
+                   [("pub_key", pubKey__field_descriptor),
                     ("power", power__field_descriptor)])
+
+absentValidators ::
+                 forall f s t a b .
+                   (Lens.Labels.HasLens "absentValidators" f s t a b) =>
+                   Lens.Family2.LensLike f s t a b
+absentValidators
+  = Lens.Labels.lensOf
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "absentValidators")
 
 appHash ::
         forall f s t a b . (Lens.Labels.HasLens "appHash" f s t a b) =>
@@ -2200,6 +3140,37 @@ beginBlock ::
 beginBlock
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "beginBlock")
+
+blockGossip ::
+            forall f s t a b . (Lens.Labels.HasLens "blockGossip" f s t a b) =>
+              Lens.Family2.LensLike f s t a b
+blockGossip
+  = Lens.Labels.lensOf
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "blockGossip")
+
+blockPartSizeBytes ::
+                   forall f s t a b .
+                     (Lens.Labels.HasLens "blockPartSizeBytes" f s t a b) =>
+                     Lens.Family2.LensLike f s t a b
+blockPartSizeBytes
+  = Lens.Labels.lensOf
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "blockPartSizeBytes")
+
+blockSize ::
+          forall f s t a b . (Lens.Labels.HasLens "blockSize" f s t a b) =>
+            Lens.Family2.LensLike f s t a b
+blockSize
+  = Lens.Labels.lensOf
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "blockSize")
+
+byzantineValidators ::
+                    forall f s t a b .
+                      (Lens.Labels.HasLens "byzantineValidators" f s t a b) =>
+                      Lens.Family2.LensLike f s t a b
+byzantineValidators
+  = Lens.Labels.lensOf
+      ((Lens.Labels.proxy#) ::
+         (Lens.Labels.Proxy#) "byzantineValidators")
 
 chainId ::
         forall f s t a b . (Lens.Labels.HasLens "chainId" f s t a b) =>
@@ -2229,6 +3200,15 @@ commit
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "commit")
 
+consensusParamUpdates ::
+                      forall f s t a b .
+                        (Lens.Labels.HasLens "consensusParamUpdates" f s t a b) =>
+                        Lens.Family2.LensLike f s t a b
+consensusParamUpdates
+  = Lens.Labels.lensOf
+      ((Lens.Labels.proxy#) ::
+         (Lens.Labels.Proxy#) "consensusParamUpdates")
+
 data' ::
       forall f s t a b . (Lens.Labels.HasLens "data'" f s t a b) =>
         Lens.Family2.LensLike f s t a b
@@ -2249,13 +3229,6 @@ deliverTx ::
 deliverTx
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "deliverTx")
-
-diffs ::
-      forall f s t a b . (Lens.Labels.HasLens "diffs" f s t a b) =>
-        Lens.Family2.LensLike f s t a b
-diffs
-  = Lens.Labels.lensOf
-      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "diffs")
 
 echo ::
      forall f s t a b . (Lens.Labels.HasLens "echo" f s t a b) =>
@@ -2285,12 +3258,26 @@ exception
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "exception")
 
+fee ::
+    forall f s t a b . (Lens.Labels.HasLens "fee" f s t a b) =>
+      Lens.Family2.LensLike f s t a b
+fee
+  = Lens.Labels.lensOf
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "fee")
+
 flush ::
       forall f s t a b . (Lens.Labels.HasLens "flush" f s t a b) =>
         Lens.Family2.LensLike f s t a b
 flush
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "flush")
+
+gas ::
+    forall f s t a b . (Lens.Labels.HasLens "gas" f s t a b) =>
+      Lens.Family2.LensLike f s t a b
+gas
+  = Lens.Labels.lensOf
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "gas")
 
 hash ::
      forall f s t a b . (Lens.Labels.HasLens "hash" f s t a b) =>
@@ -2379,6 +3366,27 @@ log
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "log")
 
+maxBytes ::
+         forall f s t a b . (Lens.Labels.HasLens "maxBytes" f s t a b) =>
+           Lens.Family2.LensLike f s t a b
+maxBytes
+  = Lens.Labels.lensOf
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maxBytes")
+
+maxGas ::
+       forall f s t a b . (Lens.Labels.HasLens "maxGas" f s t a b) =>
+         Lens.Family2.LensLike f s t a b
+maxGas
+  = Lens.Labels.lensOf
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maxGas")
+
+maxTxs ::
+       forall f s t a b . (Lens.Labels.HasLens "maxTxs" f s t a b) =>
+         Lens.Family2.LensLike f s t a b
+maxTxs
+  = Lens.Labels.lensOf
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maxTxs")
+
 maybe'beginBlock ::
                  forall f s t a b .
                    (Lens.Labels.HasLens "maybe'beginBlock" f s t a b) =>
@@ -2386,6 +3394,22 @@ maybe'beginBlock ::
 maybe'beginBlock
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'beginBlock")
+
+maybe'blockGossip ::
+                  forall f s t a b .
+                    (Lens.Labels.HasLens "maybe'blockGossip" f s t a b) =>
+                    Lens.Family2.LensLike f s t a b
+maybe'blockGossip
+  = Lens.Labels.lensOf
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'blockGossip")
+
+maybe'blockSize ::
+                forall f s t a b .
+                  (Lens.Labels.HasLens "maybe'blockSize" f s t a b) =>
+                  Lens.Family2.LensLike f s t a b
+maybe'blockSize
+  = Lens.Labels.lensOf
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'blockSize")
 
 maybe'checkTx ::
               forall f s t a b .
@@ -2402,6 +3426,15 @@ maybe'commit ::
 maybe'commit
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'commit")
+
+maybe'consensusParamUpdates ::
+                            forall f s t a b .
+                              (Lens.Labels.HasLens "maybe'consensusParamUpdates" f s t a b) =>
+                              Lens.Family2.LensLike f s t a b
+maybe'consensusParamUpdates
+  = Lens.Labels.lensOf
+      ((Lens.Labels.proxy#) ::
+         (Lens.Labels.Proxy#) "maybe'consensusParamUpdates")
 
 maybe'deliverTx ::
                 forall f s t a b .
@@ -2494,6 +3527,21 @@ maybe'setOption
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'setOption")
 
+maybe'txSize ::
+             forall f s t a b .
+               (Lens.Labels.HasLens "maybe'txSize" f s t a b) =>
+               Lens.Family2.LensLike f s t a b
+maybe'txSize
+  = Lens.Labels.lensOf
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'txSize")
+
+maybe'value ::
+            forall f s t a b . (Lens.Labels.HasLens "maybe'value" f s t a b) =>
+              Lens.Family2.LensLike f s t a b
+maybe'value
+  = Lens.Labels.lensOf
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'value")
+
 message ::
         forall f s t a b . (Lens.Labels.HasLens "message" f s t a b) =>
           Lens.Family2.LensLike f s t a b
@@ -2564,6 +3612,13 @@ setOption
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "setOption")
 
+tags ::
+     forall f s t a b . (Lens.Labels.HasLens "tags" f s t a b) =>
+       Lens.Family2.LensLike f s t a b
+tags
+  = Lens.Labels.lensOf
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "tags")
+
 time ::
      forall f s t a b . (Lens.Labels.HasLens "time" f s t a b) =>
        Lens.Family2.LensLike f s t a b
@@ -2584,6 +3639,21 @@ tx ::
 tx
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "tx")
+
+txSize ::
+       forall f s t a b . (Lens.Labels.HasLens "txSize" f s t a b) =>
+         Lens.Family2.LensLike f s t a b
+txSize
+  = Lens.Labels.lensOf
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "txSize")
+
+validatorUpdates ::
+                 forall f s t a b .
+                   (Lens.Labels.HasLens "validatorUpdates" f s t a b) =>
+                   Lens.Family2.LensLike f s t a b
+validatorUpdates
+  = Lens.Labels.lensOf
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "validatorUpdates")
 
 validators ::
            forall f s t a b . (Lens.Labels.HasLens "validators" f s t a b) =>
@@ -2606,6 +3676,27 @@ value ::
 value
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "value")
+
+valueInt ::
+         forall f s t a b . (Lens.Labels.HasLens "valueInt" f s t a b) =>
+           Lens.Family2.LensLike f s t a b
+valueInt
+  = Lens.Labels.lensOf
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "valueInt")
+
+valueString ::
+            forall f s t a b . (Lens.Labels.HasLens "valueString" f s t a b) =>
+              Lens.Family2.LensLike f s t a b
+valueString
+  = Lens.Labels.lensOf
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "valueString")
+
+valueType ::
+          forall f s t a b . (Lens.Labels.HasLens "valueType" f s t a b) =>
+            Lens.Family2.LensLike f s t a b
+valueType
+  = Lens.Labels.lensOf
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "valueType")
 
 version ::
         forall f s t a b . (Lens.Labels.HasLens "version" f s t a b) =>

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-8.15
+resolver: lts-10.3
 packages:
 - '.'
 explicit-setup-deps:


### PR DESCRIPTION
Updates package for modern tendermint version (01-2018)

Some minor changes: Counter example accepts flag --serail just like the
original go-example.

**Test**:

~~~
cd hs-abci
stack install
hs-abci-counter --serial
~~~

Try examples from docs: http://tendermint.readthedocs.io/en/master/getting-started.html#counter-another-example

From second terimanal:

~~~
tendermint unsafe_reset_all
tendermint node
~~~

From third terminal:

~~~
curl localhost:46657/broadcast_tx_commit?tx=0x00
curl localhost:46657/broadcast_tx_commit?tx=0x05
curl localhost:46657/broadcast_tx_commit?tx=0x01
~~~